### PR TITLE
Use case sensitive variable name in variable's details view

### DIFF
--- a/data/models.py
+++ b/data/models.py
@@ -122,11 +122,7 @@ class Variable(ElasticMixin, DorMixin, models.Model):
 
     def get_name_cs(self):
         """Get the case sensitive version of the variable name, if available"""
-        try:
-            name_cs = self.get_source["name_cs"]
-        except:
-            name_cs = self.name
-        return name_cs
+        return self.get_source().get("name_cs", self.name)
 
     def _construct_categories(self):
         try:

--- a/data/models.py
+++ b/data/models.py
@@ -121,8 +121,9 @@ class Variable(ElasticMixin, DorMixin, models.Model):
         return self.category_list_cache
 
     def get_name_cs(self):
+        """Get the case sensitive version of the variable name, if available"""
         try:
-            name_cs = self.get_source.get("name_cs")
+            name_cs = self.get_source["name_cs"]
         except:
             name_cs = self.name
         return name_cs

--- a/data/models.py
+++ b/data/models.py
@@ -120,6 +120,13 @@ class Variable(ElasticMixin, DorMixin, models.Model):
             self.category_list_cache = self._construct_categories()
         return self.category_list_cache
 
+    def get_name_cs(self):
+        try:
+            name_cs = self.get_source.get("name_cs")
+        except:
+            name_cs = self.name
+        return name_cs
+
     def _construct_categories(self):
         try:
             c = self.get_source().get("uni", None)

--- a/templates/data/variable_info.html
+++ b/templates/data/variable_info.html
@@ -4,8 +4,8 @@
   </div>
   <div class="panel-body">
     <p>
-      <b>Variable name:</b>
-      <a href="{{ variable }}">{{ variable.name }}</a>
+      <b>Variable name (case sensitiv):</b>
+      <a href="{{ variable }}">{{ variable.get_name_cs }}</a>
     </p>
     <p>
       <b>Dataset:</b>


### PR DESCRIPTION
Some statistical software packages are case sensitive in regard to variable names.

With this pull request, case sensitiv names are shown in the detail view of a variable.