### PR TITLE
Fix loading bar in topic list (when showing variables/questions)

### DIFF
--- a/static/src/scss/topic_list.css
+++ b/static/src/scss/topic_list.css
@@ -46,3 +46,46 @@ html,
 body {
     height: 100%;
 }
+
+/* Spinner taken from https://github.com/tobiasahlin/SpinKit */
+.spinner {
+    margin: 50px auto 0;
+    width: 70px;
+    text-align: center;
+}
+
+.spinner > div {
+    width: 18px;
+    height: 18px;
+    background-color: steelblue;
+
+    border-radius: 100%;
+    display: inline-block;
+    -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+    animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+}
+
+.spinner .bounce1 {
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+}
+
+.spinner .bounce2 {
+    -webkit-animation-delay: -0.16s;
+    animation-delay: -0.16s;
+}
+
+@-webkit-keyframes sk-bouncedelay {
+    0%, 80%, 100% { -webkit-transform: scale(0) }
+    40% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes sk-bouncedelay {
+    0%, 80%, 100% {
+        -webkit-transform: scale(0);
+        transform: scale(0);
+    } 40% {
+          -webkit-transform: scale(1.0);
+          transform: scale(1.0);
+      }
+}


### PR DESCRIPTION
Due to missing code in the css file, the loading bar didn't show up when selecting variables/questions in the topic list. This pull request adds the missing css code.