### PR TITLE
Set relative paths to templates on staging and production server

### DIFF
--- a/settings/hewing.py
+++ b/settings/hewing.py
@@ -51,7 +51,7 @@ RQ_QUEUES = {
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": ["/data/WWW/vhosts/paneldata.soep.de/ddionrails2/ddionrails/templates"],
+        "DIRS": [BASE_DIR + '/templates'],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/settings/hewing.py
+++ b/settings/hewing.py
@@ -1,4 +1,4 @@
-from .base import * # noqa
+from .base import *  # noqa
 
 WSGI_APPLICATION = "ddionrails.wsgi_hewing.application"
 
@@ -51,7 +51,7 @@ RQ_QUEUES = {
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [BASE_DIR + '/templates'],
+        "DIRS": [BASE_DIR + "/templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/settings/production.py
+++ b/settings/production.py
@@ -1,4 +1,4 @@
-from .base import * # noqa
+from .base import *  # noqa
 
 WSGI_APPLICATION = "ddionrails.wsgi_production.application"
 DEBUG = False
@@ -41,7 +41,7 @@ RQ_QUEUES = {
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [BASE_DIR + '/templates'],
+        "DIRS": [BASE_DIR + "/templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/settings/production.py
+++ b/settings/production.py
@@ -41,7 +41,7 @@ RQ_QUEUES = {
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": ["/data/WWW/vhosts/paneldata.soep.de/ddionrails2/ddionrails/templates"],
+        "DIRS": [BASE_DIR + '/templates'],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
## Proposed changes

The paths to the templates directory on the staging and production server were hard coded. This PR fixes `TemplateDoesNotExist` when the path on the server changes for example. This PR fixes #200.

## Types of changes

What types of changes does your code introduce to ddionrails?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. 
If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] Pytest passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
