### PR TITLE
Update pavement.py: two new tasks

### DIFF
--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -1,10 +1,3 @@
-#!/bin/sh
-
-##
-# Activate virtualenv.
-#
-source ~/.envs/ddionrails2/bin/activate
-
 ##
 # Initiate tmus session if not existing.
 #


### PR DESCRIPTION
Two new tasks in pavement.py

- `initial_setup` is simply a shortcut for all paver commands used for the initial setup (e.g, install elastic and setup frontend)
- `update_study` is a shortcut to update a study

There is also an update to the tmux script with regard to using pipenv now - but I guess that I'm the only one using tmux anyway...