### PR TITLE
[Docker] Add Mailserver to docker setup

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -7,6 +7,7 @@ APPS_DIR = BASE_DIR.joinpath('ddionrails')
 
 DEBUG = os.getenv("DJANGO_DEBUG", False)
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
+EMAIL_HOST = 'mail'
 ALLOWED_HOSTS = tuple(os.getenv("ALLOWED_HOSTS", default=[]).split(","))
 WSGI_APPLICATION = "config.wsgi.application"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     #  - docker/environments/elasticsearch.env
     networks:
       ddi_net:
+        # This Address is used in the nginx.example.conf and in the docker/mail/Dockerfile
+        # If you want to change it, you have to also change it there.
         ipv4_address: 172.16.238.10
         ipv6_address: 2001:3984:3989::10
     ports: 
@@ -55,6 +57,13 @@ services:
         hard: -1
     volumes:
       - elastic_data:/usr/share/elasticsearch/data
+
+  mail:
+    build:
+      context: ./docker/postfix/
+    networks:
+      - ddi_net
+
   nginx:
     image: nginx:1.15-alpine
     ports:

--- a/docker/postfix/Dockerfile
+++ b/docker/postfix/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7.3-alpine
+
+RUN apk update \
+    && apk add postfix \
+    && rm -rf /var/cache/apk/*
+
+RUN echo "mynetworks = 172.16.238.10" >> /etc/postfix/main.cf
+
+ENTRYPOINT [ "postfix", "start-fg" ]


### PR DESCRIPTION
## Proposed changes

Fix missing django mailing function by adding a postfix mail service ti the setup

## Types of changes

- Add Dockerfile to build alpine image with postfix service inside
- Add postfix service under name mail to docker-compose.yml
  - Allow only access from the ip of the django container by adding it to the /etc/postfix/main.cf
- Add EMAIL_HOST to config.settings.base and set it to the services docker internal address
