### PR TITLE
Remove --depth 1 in "git pull" (#435)

### DIFF
--- a/ddionrails/imports/management/commands/update.py
+++ b/ddionrails/imports/management/commands/update.py
@@ -1,27 +1,49 @@
-from pathlib import Path
+# -*- coding: utf-8 -*-
+""" Update management command for ddionrails project """
+
+import pathlib
 
 import djclick as click
+import git
 from django.conf import settings
-from git import Repo
 
 from ddionrails.studies.models import Study
 
 
-def update_study(study):
-    repo_dir = Path(settings.IMPORT_REPO_PATH) / study.name
-    if repo_dir.exists():
-        print("pulling")
-        repo = Repo(repo_dir)
-        repo.remotes.origin.pull(depth=1)
+def update_study(study: Study) -> None:
+    """ Clone a study's git repository with --depth=1
+        or pull changes if git repository has already been cloned.
+
+        The path to the git repository /repositories is set via the
+        settings.IMPORT_REPO_PATH variable.
+    """
+    repository_directory = pathlib.Path(settings.IMPORT_REPO_PATH) / study.name
+    if repository_directory.exists():
+        print(f'Pulling "{study.name}" from "{study.repo_url()}"')
+        repo = git.Repo(repository_directory)
+        repo.remotes.origin.pull()
     else:
-        print("cloning")
-        Repo.clone_from(study.repo_url(), repo_dir, depth=1)
+        print(f'Cloning "{study.name}" from "{study.repo_url()}"')
+        git.Repo.clone_from(study.repo_url(), repository_directory, depth=1)
 
 
 @click.command()
-@click.option("-s", "--study", "study_name", default=False)
-@click.option("-a", "--all", "_all", default=False, is_flag=True)
-def command(study_name, _all):
+@click.option("-s", "--study", "study_name", default="", help="Update a single study")
+@click.option(
+    "-a", "--all", "_all", default=False, is_flag=True, help="Update all studies"
+)
+def command(study_name: str, _all: bool) -> None:
+    """ This management command updates
+        a single study selected from the database by "study_name"
+        example usage:
+            python manage.py update -s some-study
+            python manage.py update --study some-study
+        or all studies if "_all" is True
+        example usage:
+            python manage.py update -a
+            python manage.py update --all
+    """
+
     if _all:
         for study in Study.objects.all():
             update_study(study)
@@ -29,8 +51,7 @@ def command(study_name, _all):
         try:
             study = Study.objects.get(name=study_name)
             update_study(study)
-        except Exception as e:
-            print(e)
-            print(study)
+        except Study.DoesNotExist:
+            print(f'Study "{study_name}" does not exist.')
     else:
         print("Please enter a valid study name")


### PR DESCRIPTION
## Proposed changes

If "git clone" is executed with "--depth 1" and the remote repository
gets more than 1 new commit, then "git pull --depth=1" throws an error:
"fatal: refusing to merge unrelated histories"

Fix: allow `git clone --depth=1` but use `git pull` (without --depth) later on.

## Types of changes

What types of changes does your code introduce to ddionrails?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
