### PR TITLE
449: Update codecov settings in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 before_install:
   - docker --version
   - docker-compose --version
+  - mkdir codecov # for coverage report
 #  - curl -L -o /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz
 #  - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver
 #  - export PATH=$HOME/geckodriver:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ before_script:
   - docker images
   - docker ps -a
 script:
-  - docker-compose exec web pytest
-  - docker-compose exec web pytest -m "functional" tests/functional/test_system_import.py --cov-append
-  - docker-compose exec web pytest -m "functional" tests/functional/test_imports.py --cov-append
+  - docker-compose exec web pytest --cov-report xml
+  - docker-compose exec web pytest --cov-report xml -m "functional" tests/functional/test_system_import.py --cov-append
+  - docker-compose exec web pytest --cov-report xml -m "functional" tests/functional/test_imports.py --cov-append
+  - docker-compose exec web mv coverage.xml codecov/ # move coverage report to directory, that is mounted as volume
 #  - docker-compose exec web xvfb-run pytest -m "functional" tests/functional/test_search.py --cov-append
 #  - xvfb-run pytest -s -m "functional" --driver Firefox --cov-append tests/functional/test_browser.py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 before_install:
   - docker --version
   - docker-compose --version
-  - mkdir codecov # for coverage report
+  - mkdir codecov # create directory for coverage report, that is mounted as volume
 #  - curl -L -o /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz
 #  - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver
 #  - export PATH=$HOME/geckodriver:$PATH
@@ -29,6 +29,7 @@ script:
 #  - docker-compose exec web xvfb-run pytest -m "functional" tests/functional/test_search.py --cov-append
 #  - xvfb-run pytest -s -m "functional" --driver Firefox --cov-append tests/functional/test_browser.py
 after_success:
-  - docker-compose exec web codecov
+  # see: https://docs.codecov.io/docs/testing-with-docker
+  - bash <(curl -s https://codecov.io/bash) # send coverage.xml to codecov.io
 after_script:
   - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
   - docker
 env:
   global:
+  - COMPOSE_FILE=docker-compose.yml:docker-compose-travis.yml
   - DISPLAY=:99.0
   - GECKODRIVER_VERSION=0.23.0
 addons:
@@ -16,7 +17,7 @@ before_install:
 #  - export PATH=$HOME/geckodriver:$PATH
 #  - geckodriver --version
 before_script:
-  - docker-compose -f "docker-compose.yml" -f "docker-compose-travis.yml" up --build -d
+  - docker-compose up --build -d
   - docker images
   - docker ps -a
 script:
@@ -28,4 +29,4 @@ script:
 after_success:
   - docker-compose exec web codecov
 after_script:
-  - docker-compose -f "docker-compose.yml" -f "docker-compose-travis.yml" down
+  - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 dist: xenial
 sudo: required
-language: python
 services:
   - docker
-python:
-  - "3.7"
 env:
   global:
   - DISPLAY=:99.0

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -8,6 +8,8 @@ services:
       - docker/environments/elasticsearch.env.example
     environment:
       DJANGO_SETTINGS_MODULE: config.settings.testing
+    volumes:
+      - ./codecov:/usr/src/app/codecov
   postgres:
     env_file:
       - docker/environments/database.env.example


### PR DESCRIPTION
## Proposed changes
codecov did not get any updates from the Travis CI test runs anymore since the switch to a docker base setup. This PR changes the "transport" of the coverage report to codecov.io as described in <https://docs.codecov.io/docs/testing-with-docker>.
I added a volume in docker-compose-travis.yml to store the `coverage.xml` report, that gets send to codecov from Travis CI, outside of the docker containers.
It works, therefore we have updated code coverage again. See:
<https://codecov.io/gh/ddionrails/ddionrails/commit/7cc5de96bdde79430de24604b01664387b4e1292>

Related issue: #449 


## Types of changes

What types of changes does your code introduce to ddionrails?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. 
If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] Pytest passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)