### PR TITLE
445: Fix tests for api app that break when run twice

### DIFF
--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -1,21 +1,24 @@
+# -*- coding: utf-8 -*-
+""" Test cases for ddionrails.api app """
+
 class TestObjectRedirectView:
     def test_variable_redirect(self, client, variable):
-        url = "/api/test/redirect/variable/1"
+        url = f"/api/test/redirect/variable/{variable.id}"
         response = client.get(url)
         assert 302 == response.status_code
 
     def test_publication_redirect(self, client, publication):
-        url = "/api/test/redirect/publication/1"
+        url = f"/api/test/redirect/publication/{publication.id}"
         response = client.get(url)
         assert 302 == response.status_code
 
     def test_question_redirect(self, client, question):
-        url = "/api/test/redirect/question/1"
+        url = f"/api/test/redirect/question/{question.id}"
         response = client.get(url)
         assert 302 == response.status_code
 
     def test_concept_redirect(self, client, concept):
-        url = "/api/test/redirect/concept/1"
+        url = f"/api/test/redirect/concept/{concept.id}"
         response = client.get(url, follow=True)
         assert 200 == response.status_code
         assert response.redirect_chain[-1][0] == concept.get_absolute_url()


### PR DESCRIPTION
## Proposed changes

The hardcoded ones caused breaking test cases when the tests ran twice.

Fix: Replace the 1 with the actual ID of the object in the database, which can be > 1.

Related issue: #445

## Types of changes

What types of changes does your code introduce to ddionrails?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. 
If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] Pytest passes locally with my changes