### PR TITLE
427: Change returned Queryset of Question.get_concepts() method

### DIFF
--- a/ddionrails/instruments/models.py
+++ b/ddionrails/instruments/models.py
@@ -1,8 +1,12 @@
+# -*- coding: utf-8 -*-
+""" Model definitions for ddionrails.instruments app """
+
 import copy
 import textwrap
 from collections import OrderedDict
 
 from django.db import models
+from django.db.models import QuerySet
 from django.urls import reverse
 from model_utils.managers import InheritanceManager
 
@@ -161,13 +165,13 @@ class Question(ElasticMixin, DorMixin, models.Model):
         else:
             return combined_set
 
-    def get_concepts(self):
-        direct_concepts = Concept.objects.filter(concepts_questions__question_id=self.pk)
-        indirect_concepts = Concept.objects.filter(
-            variables__questions_variables__question_id=self.pk
-        )
-        result = direct_concepts | indirect_concepts
-        return result.distinct()
+    def get_concepts(self) -> QuerySet:
+        """ Retrieve the related Concepts of this Question
+
+            A question and concept are related if
+            their relation is defined in ConceptQuestion.
+        """
+        return Concept.objects.filter(concepts_questions__question_id=self.pk).distinct()
 
     def concept_list(self):
         """DEPRECATED NAME"""

--- a/tests/instruments/test_models.py
+++ b/tests/instruments/test_models.py
@@ -1,4 +1,9 @@
+# -*- coding: utf-8 -*-
+""" Test cases for ddionrails.instruments.models """
+
 import pytest
+
+from ddionrails.instruments.models import ConceptQuestion
 
 pytestmark = [pytest.mark.instrument, pytest.mark.models]
 
@@ -35,8 +40,19 @@ class TestQuestionModel:
     def test_next_question_method(self):
         pass
 
-    def test_concept_list_method(self):
-        pass
+    def test_get_concepts_method_no_concept(self, question):
+        """ Test Question.get_concepts() without concept-question-relation """
+        result = question.get_concepts()
+        assert 0 == result.count()
+
+    def test_get_concepts_method_single_concept(self, question, concept):
+        """ Test Question.get_concepts() with concept-question-relation"""
+
+        # create a relation between question and concept
+        ConceptQuestion.objects.create(concept=concept, question=question)
+        result = question.get_concepts()
+        assert 1 == result.count()
+        assert concept == result.first()
 
     def test_get_cs_name_method(self):
         pass


### PR DESCRIPTION
## Proposed changes

The Question.get_concepts() method should return "direct_concepts" only.
The "indirect_concepts" should not be returned.

See https://github.com/ddionrails/ddionrails/issues/427#issuecomment-490875348

Related issue: #427

## Types of changes

What types of changes does your code introduce to ddionrails?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. 
If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] Pytest passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
