### PR TITLE
459: Remove unused codecov library from Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -47,7 +47,6 @@ black = "==19.3b0" # pin until black leaves pre-release status
 flake8 = "*"
 isort = "*"
 mypy = "*"
-codecov = "*"
 pre-commit = "*"
 
 # Testing

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a9dd19799242ff91a44cb5a1c470bb8fe86915f573ecbd5493e6d5bfcac06067"
+            "sha256": "d220bffd6f70643ba01da4b84f4add96b66e3afb56d22331c926243df48f14c0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -69,11 +69,11 @@
         },
         "django-extensions": {
             "hashes": [
-                "sha256:109004f80b6f45ad1f56addaa59debca91d94aa0dc1cb19678b9364b4fe9b6f4",
-                "sha256:307766e5e6c1caffe76c5d99239d8115d14ae3f7cab2cd991fcffd763dad904b"
+                "sha256:6766c573ffe63693cd485512a02f3b59622c884cbfeca241d1278ffdf0ac39ae",
+                "sha256:c43e46cc95985c278afda645480b79f9a85cfe5a82c957accd08b8045793b707"
             ],
             "index": "pypi",
-            "version": "==2.1.6"
+            "version": "==2.1.7"
         },
         "django-import-export": {
             "hashes": [
@@ -401,14 +401,6 @@
             ],
             "version": "==7.0"
         },
-        "codecov": {
-            "hashes": [
-                "sha256:8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788",
-                "sha256:ae00d68e18d8a20e9c3288ba3875ae03db3a8e892115bf9b83ef20507732bed4"
-            ],
-            "index": "pypi",
-            "version": "==2.0.15"
-        },
         "coverage": {
             "hashes": [
                 "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
@@ -544,10 +536,10 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2f2e54cbf6b06b16351e4c40a6adb0860cab6cfb95a0c0fcb58bb789c4b450f5",
-                "sha256:37bbea81dec44d1ff72d58a1b5c1599a9f3436537f33e9e26f276610064c4830"
+                "sha256:0e375a4c177090292988d1c2f997c7c2467d908c1adbed3e08fb511486c85457",
+                "sha256:440815529340fb7fdd6a83ebf4258cc2860fb3770d37b52875e37c6f509a4cd6"
             ],
-            "version": "==0.12"
+            "version": "==0.13"
         },
         "isort": {
             "hashes": [


### PR DESCRIPTION
## Proposed changes

The Codecov python library is not used anymore for uploading of coverage reports to codecov.io.

Related issue: #459