### PR TITLE
[LICENSE] Split copyright notice to separate file

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,26 @@
+This file is part of DDI on Rails.
+
+DDI on Rails is free software: you can redistribute it and/or modify  
+it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE as  
+published by the Free Software Foundation, either version 3 of the  
+License, or (at your option) any later version.
+
+DDI on Rails is distributed in the hope that it will be useful,  
+but WITHOUT ANY WARRANTY; without even the implied warranty of  
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the  
+GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+
+You should have received a copy of the GNU AFFERO GENERAL PUBLIC LICENSE  
+along with DDI on Rails.  If not, see <https://www.gnu.org/licenses/>.
+
+
+- version   : >=2.1.0 (AGPLv3 License)
+- authors   :
+  - 2015-2019 Marcel Hebing (DIW Berlin)
+  - 2018-2019 Heinz-Alexander Fütterer (DIW Berlin)
+  - 2019 Dominique Hansen (DIW Berlin)
+- date      : 2018-11-30
+- copyright : Copyright (c) 2015-2019, Marcel Hebing, DIW Berlin <https://www.diw.de/>. All rights reserved.
+- license   : GNU AFFERO GENERAL PUBLIC LICENSE (AGPL) 3.0.  
+               See LICENSE at <https://github.com/ddionrails/ddionrails/blob/master/LICENSE.md>.  
+               See AGPL License at <https://www.gnu.org/licenses/agpl-3.0.txt>.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,28 +1,4 @@
-/********
- * This file is part of DDI on Rails.
- *
- * DDI on Rails is free software: you can redistribute it and/or modify
- * it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * DDI on Rails is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
- *
- * You should have received a copy of the GNU AFFERO GENERAL PUBLIC LICENSE
- * along with DDI on Rails.  If not, see <https://www.gnu.org/licenses/>.
- *
- *
- * @version   : 2.1.0 (AGPLv3 License)
- * @author    : Marcel Hebing (DIW Berlin)
- * @date      : 2018-11-30
- * @copyright : Copyright (c) 2015-2018, DIW Berlin (https://www.diw.de/). All rights reserved.
- * @license   : GNU AFFERO GENERAL PUBLIC LICENSE (AGPL) 3.0.
- *              See LICENSE and https://github.com/ddionrails/ddionrails/blob/master/LICENSE.
- *              See AGPL License at https://www.gnu.org/licenses/agpl-3.0.txt
- ********/
+Copyright: See the [copyright file](./COPYRIGHT.md)
 
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007


### PR DESCRIPTION
## Proposed changes

GitHub uses [licensee](https://github.com/licensee/licensee) to identify the license of a project.
Licensee does not recognize the license in LICENSE.md with the copyright notice directly written into the File.

This Change Splits the copyright notice head into a separate file and links to it in the LICENSE.md.
With this change licensee recognizes the license with 99.63% confidence.

## Types of changes

Documentation/License refactoring

## Checklist

N.A.
