### PR TITLE
440: Improve ModelAdmins

### DIFF
--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -1,6 +1,7 @@
 from .base import *  # noqa
 
 DEBUG = True
+TEMPLATE_DEBUG = True
 
 # django-debug-toolbar
 # ------------------------------------------------------------------------------
@@ -10,6 +11,12 @@ INSTALLED_APPS += ("debug_toolbar",)
 MIDDLEWARE = ("debug_toolbar.middleware.DebugToolbarMiddleware",) + MIDDLEWARE
 # https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#debug-toolbar-config
 INTERNAL_IPS = ("127.0.0.1",)
+
+# credit to https://stackoverflow.com/a/50332425
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': lambda request: True
+}
+
 
 SYSTEM_NAME = "system"
 SYSTEM_REPO_URL = "https://github.com/ddionrails/test-system.git"

--- a/config/urls.py
+++ b/config/urls.py
@@ -21,6 +21,10 @@ handler403 = "config.views.permission_denied"
 handler404 = "config.views.page_not_found"
 handler500 = "config.views.server_error"
 
+admin.site.site_header = 'DDI on Rails Admin'
+admin.site.site_title = 'DDI on Rails Admin'
+admin.site.index_title = 'Welcome to DDI on Rails Admin'
+
 urlpatterns = [
     path("", HomePageView.as_view(), name="homepage"),
     path("imprint/", imprint_page, name="imprint"),

--- a/ddionrails/base/mixins.py
+++ b/ddionrails/base/mixins.py
@@ -156,3 +156,87 @@ class ModelMixin:
 
     def __str__(self):
         return self.string_id()
+
+
+class AdminMixin:
+    """ A mixin for ModelAdmins to query related models via methods """
+
+    @staticmethod
+    def study_name(obj):
+        """ Return the name of the related study """
+        try:
+            return obj.study.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def period_name(obj):
+        """ Return the name of the related period """
+        try:
+            return obj.period.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def analysis_unit_name(obj):
+        """ Return the name of the related analysis_unit """
+        try:
+            return obj.analysis_unit.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def dataset_name(obj):
+        """ Return the name of the related dataset """
+        try:
+            return obj.dataset.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def dataset_study_name(obj):
+        """ Return the name of the related dataset.study """
+        try:
+            return obj.dataset.study.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def instrument_name(obj):
+        """ Return the name of the related instrument """
+        try:
+            return obj.instrument.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def instrument_study_name(obj):
+        """ Return the name of the related instrument.study """
+        try:
+            return obj.instrument.study.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def basket_name(obj):
+        """ Return the name of the related basket """
+        try:
+            return obj.basket.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def basket_study_name(obj):
+        """ Return the name of the related basket.study """
+        try:
+            return obj.basket.study.name
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def user_name(obj):
+        """ Return the name of the related basket.user """
+        try:
+            return obj.basket.user.username
+        except AttributeError:
+            return None

--- a/ddionrails/concepts/admin.py
+++ b/ddionrails/concepts/admin.py
@@ -1,26 +1,62 @@
+# -*- coding: utf-8 -*-
+""" ModelAdmin definitions for ddionrails.concepts app """
+
 from django.contrib import admin
 
-from .models import AnalysisUnit, Concept, ConceptualDataset, Period
+from ddionrails.base.mixins import AdminMixin
+
+from .models import AnalysisUnit, Concept, ConceptualDataset, Period, Topic
 
 
 @admin.register(AnalysisUnit)
 class AnalysisUnitAdmin(admin.ModelAdmin):
-    list_display = ("name", "label")
+    """ ModelAdmin for concepts.AnalysisUnit """
+
+    list_display = ("name", "label", "label_de")
+    list_per_page = 25
+    search_fields = ("name", "label", "label_de")
 
 
 @admin.register(Concept)
 class ConceptAdmin(admin.ModelAdmin):
-    list_display = ("name", "label")
+    """ ModelAdmin for concepts.Concept """
+
+    list_display = ("name", "label", "label_de")
+    list_per_page = 25
+    raw_id_fields = ("topics",)
+    search_fields = ("name", "label", "label_de")
 
 
 @admin.register(ConceptualDataset)
 class ConceptualDatasetAdmin(admin.ModelAdmin):
-    list_display = ("name", "label")
+    """ ModelAdmin for concepts.ConceptualDataset """
+
+    list_display = ("name", "label", "label_de")
+    list_per_page = 25
+    search_fields = ("name", "label", "label_de")
 
 
 @admin.register(Period)
-class PeriodAdmin(admin.ModelAdmin):
-    list_display = ("name", "study")
-    list_filter = ("study",)
+class PeriodAdmin(AdminMixin, admin.ModelAdmin):
+    """ ModelAdmin for concepts.Period """
+
+    list_display = ("name", "label", "study_name")
+    list_filter = ("study__name",)
     list_per_page = 25
-    search_fields = ("name",)
+    list_select_related = ("study",)
+    raw_id_fields = ("study",)
+    search_fields = ("name", "label")
+
+    AdminMixin.study_name.admin_order_field = "study"
+    AdminMixin.study_name.short_description = "study"
+
+
+@admin.register(Topic)
+class TopicAdmin(admin.ModelAdmin):
+    """ ModelAdmin for concepts.Topic """
+
+    list_display = ("name", "label", "label_de")
+    list_filter = ("study__name",)
+    list_per_page = 25
+    raw_id_fields = ("study", "parent")
+    search_fields = ("name", "label", "label_de")

--- a/ddionrails/data/admin.py
+++ b/ddionrails/data/admin.py
@@ -1,39 +1,54 @@
+# -*- coding: utf-8 -*-
+""" ModelAdmin definitions for ddionrails.data app """
+
 from django.contrib import admin
 
-from .models import Dataset, Variable
+from ddionrails.base.mixins import AdminMixin
+
+from .models import Dataset, Transformation, Variable
 
 
 @admin.register(Dataset)
-class DatasetAdmin(admin.ModelAdmin):
-    list_display = ("name", "label", "get_study_name", "period", "analysis_unit")
-    list_filter = ("study__name", "period__name", "analysis_unit__name")
+class DatasetAdmin(AdminMixin, admin.ModelAdmin):
+    """ ModelAdmin for data.Dataset """
+
+    list_display = ("name", "label", "study_name", "period_name", "analysis_unit_name")
+    list_filter = ("study__name", "analysis_unit__name", "period__name")
     list_per_page = 25
-    search_fields = ("name",)
     list_select_related = ("study", "period", "analysis_unit")
+    raw_id_fields = ("study", "conceptual_dataset", "period", "analysis_unit")
+    search_fields = ("name", "label")
 
-    def get_study_name(self, obj):
-        return obj.study.name
-
-    get_study_name.admin_order_field = "study"
-    get_study_name.short_description = "study"
+    AdminMixin.study_name.admin_order_field = "study"
+    AdminMixin.study_name.short_description = "study"
+    AdminMixin.period_name.admin_order_field = "period"
+    AdminMixin.period_name.short_description = "period"
+    AdminMixin.analysis_unit_name.admin_order_field = "analysis_unit"
+    AdminMixin.analysis_unit_name.short_description = "analysis_unit"
 
 
 @admin.register(Variable)
-class VariableAdmin(admin.ModelAdmin):
-    list_display = ("name", "label", "get_dataset_name", "get_study_name")
+class VariableAdmin(AdminMixin, admin.ModelAdmin):
+    """ ModelAdmin for data.Variable """
+
+    list_display = ("name", "label", "dataset_name", "dataset_study_name")
     list_filter = ("dataset__study__name",)
     list_per_page = 25
-    search_fields = ("name", "label")
     list_select_related = ("dataset", "dataset__study")
+    raw_id_fields = ("dataset", "concept", "period")
+    search_fields = ("name", "label")
 
-    def get_dataset_name(self, obj):
-        return obj.dataset.name
+    AdminMixin.dataset_name.admin_order_field = "dataset"
+    AdminMixin.dataset_name.short_description = "dataset"
+    AdminMixin.dataset_study_name.admin_order_field = "study"
+    AdminMixin.dataset_study_name.short_description = "study"
 
-    get_dataset_name.admin_order_field = "dataset"
-    get_dataset_name.short_description = "dataset"
 
-    def get_study_name(self, obj):
-        return obj.dataset.study.name
+@admin.register(Transformation)
+class TransformationAdmin(admin.ModelAdmin):
+    """ ModelAdmin for data.Transformation """
 
-    get_study_name.admin_order_field = "study"
-    get_study_name.short_description = "study"
+    list_display = ("origin_id", "target_id")
+    list_per_page = 25
+    list_select_related = ("origin", "target")
+    raw_id_fields = ("origin", "target")

--- a/ddionrails/instruments/admin.py
+++ b/ddionrails/instruments/admin.py
@@ -1,25 +1,78 @@
-from django.contrib import admin
+# -*- coding: utf-8 -*-
+""" ModelAdmin definitions for ddionrails.instruments app """
 
-from .models import Instrument, Question
+from django.contrib import admin
+from django.core.handlers.wsgi import WSGIRequest
+from model_utils.managers import InheritanceQuerySet
+
+from ddionrails.base.mixins import AdminMixin
+
+from .models import ConceptQuestion, Instrument, Question, QuestionVariable
 
 
 @admin.register(Instrument)
-class InstrumentAdmin(admin.ModelAdmin):
-    list_display = ("name", "study", "period", "analysis_unit")
-    list_filter = ("study", "period", "analysis_unit")
+class InstrumentAdmin(AdminMixin, admin.ModelAdmin):
+    """ ModelAdmin for instruments.Instrument """
+
+    list_display = ("name", "label", "study_name", "period_name", "analysis_unit_name")
+    list_filter = ("study", "analysis_unit", "period")
     list_per_page = 25
-    search_fields = ("name",)
+    list_select_related = ("study", "period", "analysis_unit")
+    raw_id_fields = ("study", "period", "analysis_unit")
+    search_fields = ("name", "label")
+
+    AdminMixin.study_name.admin_order_field = "study"
+    AdminMixin.study_name.short_description = "study"
+    AdminMixin.period_name.admin_order_field = "period"
+    AdminMixin.period_name.short_description = "period"
+    AdminMixin.analysis_unit_name.admin_order_field = "analysis_unit"
+    AdminMixin.analysis_unit_name.short_description = "analysis_unit"
 
 
 @admin.register(Question)
-class QuestionAdmin(admin.ModelAdmin):
-    list_display = ("sort_id", "name", "label", "instrument")
-    list_filter = ("instrument__name",)
+class QuestionAdmin(AdminMixin, admin.ModelAdmin):
+    """ ModelAdmin for instruments.Question """
+
+    list_display = (
+        "sort_id",
+        "name",
+        "label",
+        "instrument_name",
+        "instrument_study_name",
+    )
+    list_filter = ("instrument__study__name", "instrument__name")
     list_per_page = 25
+    raw_id_fields = ("instrument",)
     search_fields = ("name", "label")
     list_select_related = ("instrument", "instrument__study")
 
-    def get_queryset(self, request):
+    def get_queryset(self, request: WSGIRequest) -> InheritanceQuerySet:
+        """ Return an ordered queryset of questions """
         queryset = super().get_queryset(request)
-        queryset = queryset.order_by("sort_id")
+        queryset = queryset.order_by("instrument", "sort_id")
         return queryset
+
+    AdminMixin.instrument_name.admin_order_field = "instrument"
+    AdminMixin.instrument_name.short_description = "instrument"
+    AdminMixin.instrument_study_name.admin_order_field = "study"
+    AdminMixin.instrument_study_name.short_description = "study"
+
+
+@admin.register(ConceptQuestion)
+class ConceptQuestionAdmin(admin.ModelAdmin):
+    """ ModelAdmin for instruments.ConceptQuestion """
+
+    list_display = ("concept_id", "question_id")
+    list_per_page = 25
+    list_select_related = ("concept", "question")
+    raw_id_fields = ("concept", "question")
+
+
+@admin.register(QuestionVariable)
+class QuestionVariableAdmin(admin.ModelAdmin):
+    """ ModelAdmin for instruments.QuestionVariable """
+
+    list_display = ("question_id", "variable_id")
+    list_per_page = 25
+    list_select_related = ("question", "variable")
+    raw_id_fields = ("question", "variable")

--- a/ddionrails/publications/admin.py
+++ b/ddionrails/publications/admin.py
@@ -1,25 +1,60 @@
+# -*- coding: utf-8 -*-
+""" ModelAdmin definitions for ddionrails.publications app """
+
 from django.contrib import admin
+
+from ddionrails.base.mixins import AdminMixin
 
 from .models import Attachment, Publication
 
 
 @admin.register(Attachment)
 class AttachmentAdmin(admin.ModelAdmin):
-    list_display = ("study", "dataset", "variable", "instrument", "question")
-    list_per_page = 25
+    """ ModelAdmin for publications.Attachment """
 
-    def get_queryset(self, request):
-        queryset = (
-            super()
-            .get_queryset(request)
-            .select_related("study", "dataset", "variable", "instrument", "question")
-        )
-        return queryset
+    list_display = (
+        "context_study",
+        "study",
+        "dataset",
+        "variable",
+        "instrument",
+        "question",
+    )
+    list_filter = ("context_study",)
+    list_per_page = 25
+    list_select_related = (
+        "context_study",
+        "study",
+        "instrument",
+        "instrument__study",
+        "dataset",
+        "dataset__study",
+        "variable",
+        "variable__dataset",
+        "variable__dataset__study",
+    )
+    raw_id_fields = ("context_study", "study", "instrument", "dataset", "variable")
+    fields = (
+        "context_study",
+        "url",
+        "url_text",
+        "study",
+        "instrument",
+        "dataset",
+        "variable",
+    )
 
 
 @admin.register(Publication)
-class PublicationAdmin(admin.ModelAdmin):
-    list_display = ("name", "title", "author", "study", "year")
-    list_select_related = ("study",)
+class PublicationAdmin(AdminMixin, admin.ModelAdmin):
+    """ ModelAdmin for publications.Publication """
+
+    list_display = ("name", "title", "author", "study_name", "sub_type", "year")
+    list_filter = ("study", "year", "sub_type")
     list_per_page = 25
+    list_select_related = ("study",)
+    raw_id_fields = ("study",)
     search_fields = ("name", "title", "author")
+
+    AdminMixin.study_name.admin_order_field = "study"
+    AdminMixin.study_name.short_description = "study"

--- a/ddionrails/studies/admin.py
+++ b/ddionrails/studies/admin.py
@@ -1,4 +1,9 @@
+# -*- coding: utf-8 -*-
+""" ModelAdmin definitions for ddionrails.studies app """
+
 from django.contrib import admin
+from django.core.handlers.wsgi import WSGIRequest
+from django.db.models import Count, QuerySet
 
 from .models import Study
 
@@ -11,4 +16,47 @@ class StudyInline(admin.TabularInline):
 
 @admin.register(Study)
 class StudyAdmin(admin.ModelAdmin):
-    list_display = ("name", "label", "created", "modified")
+    """ ModelAdmin for studies.Study """
+
+    list_display = (
+        "name",
+        "label",
+        "dataset_count",
+        "instrument_count",
+        "basket_count",
+        "created",
+        "modified",
+    )
+    list_per_page = 25
+
+    def get_queryset(self, request: WSGIRequest) -> QuerySet:
+        """ Annotate the queryset with aggregated counts of related models """
+        queryset = super().get_queryset(request)
+        queryset = queryset.annotate(
+            _dataset_count=Count("datasets", distinct=True),
+            _instrument_count=Count("instruments", distinct=True),
+            _basket_count=Count("baskets", distinct=True),
+        )
+        return queryset
+
+    @staticmethod
+    def dataset_count(obj: Study) -> int:
+        """ Return the number of related datasets from the annotated queryset """
+        return obj._dataset_count
+
+    @staticmethod
+    def instrument_count(obj: Study) -> int:
+        """ Return the number of related instruments from the annotated queryset """
+        return obj._instrument_count
+
+    @staticmethod
+    def basket_count(obj: Study) -> int:
+        """ Return the number of related baskets from the annotated queryset """
+        return obj._basket_count
+
+    dataset_count.admin_order_field = "_dataset_count"
+    dataset_count.short_description = "Datasets"
+    instrument_count.admin_order_field = "_instrument_count"
+    instrument_count.short_description = "Instruments"
+    basket_count.admin_order_field = "_basket_count"
+    basket_count.short_description = "Baskets"

--- a/ddionrails/studies/models.py
+++ b/ddionrails/studies/models.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+""" Model definitions for ddionrails.studies app """
+
 import os
 
 from django.conf import settings
@@ -12,6 +15,7 @@ from ddionrails.elastic.mixins import ModelMixin as ElasticMixin
 
 class TopicList(ElasticMixin):
 
+    # Used by ElasticMixin when indexed into Elasticsearch
     DOC_TYPE = "topiclist"
 
     def __init__(self, study):
@@ -25,6 +29,7 @@ class Study(ElasticMixin, DorMixin, TimeStampedModel):
     :model:`concepts.Period` and :model:`workspace.Basket`.
     """
 
+    # attributes
     name = models.CharField(
         max_length=255, unique=True, db_index=True, help_text="Name of the study"
     )
@@ -58,14 +63,27 @@ class Study(ElasticMixin, DorMixin, TimeStampedModel):
         default=dict, blank=True, null=True, help_text="Configuration of the study (JSON)"
     )
 
+    # Used by ElasticMixin when indexed into Elasticsearch
     DOC_TYPE = "study"
 
     class Meta:
+        """ Django's metadata options """
+
         verbose_name_plural = "Studies"
 
     class DOR:
+        """ ddionrails' metadata options """
+
         io_fields = ["name", "label", "description"]
         id_fields = ["name"]
+
+    def __str__(self) -> str:
+        """ Returns a string representation using the "name" field """
+        return f"/{self.name}"
+
+    def get_absolute_url(self) -> str:
+        """ Returns a canonical URL for the model using the "name" field """
+        return reverse("study_detail", kwargs={"study_name": self.name})
 
     def import_path(self):
         path = os.path.join(
@@ -80,12 +98,6 @@ class Study(ElasticMixin, DorMixin, TimeStampedModel):
             return f"git@{self.repo}.git"
         else:
             raise Exception("Specify a protocol for Git in your settings.")
-
-    def __str__(self):
-        return f"/{self.name}"
-
-    def get_absolute_url(self):
-        return reverse("study_detail", kwargs={"study_name": self.name})
 
     def set_topiclist(self, body):
         t = TopicList(self)

--- a/ddionrails/workspace/admin.py
+++ b/ddionrails/workspace/admin.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+""" ModelAdmin definitions for ddionrails.workspace app """
+
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 from import_export.admin import ImportExportMixin, ImportExportModelAdmin, ImportMixin
+
+from ddionrails.base.mixins import AdminMixin
 
 from .models import Basket, BasketVariable, Script
 from .resources import (
@@ -13,42 +18,70 @@ from .resources import (
 
 
 @admin.register(Basket)
-class BasketAdmin(ImportExportModelAdmin):
-    """ The basket admin can import and export script files """
+class BasketAdmin(AdminMixin, ImportExportModelAdmin):
+    """ ModelAdmin for workspace.Basket
+        The BasketAdmin can import and export basket files
+    """
 
-    fields = (
-        "name",
-        "label",
-        "description",
-        "security_token",
-        "user",
-        "study",
-        "created",
-        "modified",
-    )
+    fields = ("name", "label", "description", "user", "study", "created", "modified")
     readonly_fields = ("created", "modified")
-    list_display = ("name", "user", "study", "created", "modified")
+    list_display = ("name", "user", "study_name", "created", "modified")
+    list_filter = ("study",)
+    list_per_page = 25
     resource_class = BasketResource
+    raw_id_fields = ("user", "study")
+    search_fields = ("name", "label", "description")
+
+    AdminMixin.study_name.admin_order_field = "study"
+    AdminMixin.study_name.short_description = "study"
 
 
 @admin.register(BasketVariable)
-class BasketVariableAdmin(ImportMixin, admin.ModelAdmin):
-    """ The basket variable admin can import script files """
+class BasketVariableAdmin(AdminMixin, ImportMixin, admin.ModelAdmin):
+    """ ModelAdmin for workspace.BasketVariable
+        The BasketVariableAdmin can import basket-variable files
+    """
 
-    list_display = ("basket", "variable")
-    list_per_page = 10
+    list_display = ("basket", "basket_study_name", "variable_id")
+    list_filter = ("basket__study",)
+    list_per_page = 25
+    list_select_related = ("basket", "variable")
     resource_class = BasketVariableImportResource
+    raw_id_fields = ("basket", "variable")
+
+    AdminMixin.basket_study_name.admin_order_field = "study"
+    AdminMixin.basket_study_name.short_description = "study"
 
 
 @admin.register(Script)
-class ScriptAdmin(ImportMixin, admin.ModelAdmin):
-    """ The script admin can import script files """
+class ScriptAdmin(AdminMixin, ImportMixin, admin.ModelAdmin):
+    """ ModelAdmin for workspace.Script
+        The ScriptAdmin can import script files
+    """
 
-    list_select_related = ("basket",)
-    list_display = ("name", "basket", "created", "modified")
-    list_per_page = 10
+    list_display = (
+        "name",
+        "user_name",
+        "basket_name",
+        "basket_study_name",
+        "generator_name",
+        "created",
+        "modified",
+    )
+    list_filter = ("basket__study",)
+    list_per_page = 25
+    list_select_related = ("basket", "basket__user")
+    raw_id_fields = ("basket",)
     readonly_fields = ("created", "modified")
     resource_class = ScriptImportResource
+    search_fields = ("name", "label", "generator_name")
+
+    AdminMixin.basket_study_name.admin_order_field = "study"
+    AdminMixin.basket_study_name.short_description = "study"
+    AdminMixin.user_name.admin_order_field = "user"
+    AdminMixin.user_name.short_description = "user"
+    AdminMixin.basket_name.admin_order_field = "basket"
+    AdminMixin.basket_name.short_description = "basket"
 
 
 class ImportExportUserAdmin(ImportExportMixin, UserAdmin):

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,6 +13,7 @@ services:
       - ./local:/usr/src/app/local
       - ./tests:/usr/src/app/tests
       - ./templates:/usr/src/app/templates
+      - ./htmlcov:/usr/src/app/htmlcov
 
   postgres:
     env_file:

--- a/tests/base/test_mixins.py
+++ b/tests/base/test_mixins.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.forms import ModelForm
 
 import ddionrails.base
-from ddionrails.base.mixins import ModelMixin
+from ddionrails.base.mixins import AdminMixin, ModelMixin
 from ddionrails.concepts.models import Concept
 
 pytestmark = [pytest.mark.ddionrails, pytest.mark.mixins]
@@ -121,3 +121,152 @@ class TestModelMixin:
         with mocker.patch("ddionrails.base.mixins.ModelMixin.string_id", return_value=""):
             assert str(mixin) == ""
             mixin.string_id.assert_called_once()
+
+
+@pytest.fixture
+def admin_mixin():
+    """ An instantiated admin mixin"""
+    return AdminMixin()
+
+
+class TestAdminMixin:
+    @staticmethod
+    def test_study_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.study.name = "some-study"
+        result = admin_mixin.study_name(obj)
+        assert obj.study.name == result
+
+    @staticmethod
+    def test_study_name_without_study(admin_mixin, mocker):
+        obj = mocker.Mock()
+        # This object has no study attribute
+        del obj.study
+        result = admin_mixin.study_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_period_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.period.name = "some-period"
+        result = admin_mixin.period_name(obj)
+        assert obj.period.name == result
+
+    @staticmethod
+    def test_period_name_without_period(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.period
+        result = admin_mixin.period_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_analysis_unit_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.analysis_unit.name = "some-analysis_unit"
+        result = admin_mixin.analysis_unit_name(obj)
+        assert obj.analysis_unit.name == result
+
+    @staticmethod
+    def test_analysis_unit_name_without_analysis_unit(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.analysis_unit
+        result = admin_mixin.analysis_unit_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_dataset_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.dataset.name = "some-dataset"
+        result = admin_mixin.dataset_name(obj)
+        assert obj.dataset.name == result
+
+    @staticmethod
+    def test_dataset_name_without_dataset(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.dataset
+        result = admin_mixin.dataset_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_dataset_study_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.dataset.study.name = "some-study"
+        result = admin_mixin.dataset_study_name(obj)
+        assert obj.dataset.study.name == result
+
+    @staticmethod
+    def test_dataset_study_name_without_study(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.dataset
+        result = admin_mixin.dataset_study_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_instrument_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.instrument.name = "some-instrument"
+        result = admin_mixin.instrument_name(obj)
+        assert obj.instrument.name == result
+
+    @staticmethod
+    def test_instrument_name_without_instrument(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.instrument
+        result = admin_mixin.instrument_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_instrument_study_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.instrument.study.name = "some-study"
+        result = admin_mixin.instrument_study_name(obj)
+        assert obj.instrument.study.name == result
+
+    @staticmethod
+    def test_instrument_study_name_without_instrument(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.instrument
+        result = admin_mixin.instrument_study_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_basket_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.basket.name = "some-basket"
+        result = admin_mixin.basket_name(obj)
+        assert obj.basket.name == result
+
+    @staticmethod
+    def test_basket_name_without_study(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.basket
+        result = admin_mixin.basket_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_basket_study_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.basket.study.name = "some-study"
+        result = admin_mixin.basket_study_name(obj)
+        assert obj.basket.study.name == result
+
+    @staticmethod
+    def test_basket_study_name_without_basket(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.basket
+        result = admin_mixin.basket_study_name(obj)
+        assert None is result
+
+    @staticmethod
+    def test_user_name(admin_mixin, mocker):
+        obj = mocker.Mock()
+        obj.basket.user.username = "some-user"
+        result = admin_mixin.user_name(obj)
+        assert obj.basket.user.username == result
+
+    @staticmethod
+    def test_user_name_without_user(admin_mixin, mocker):
+        obj = mocker.Mock()
+        del obj.basket
+        result = admin_mixin.user_name(obj)
+        assert None is result

--- a/tests/concepts/test_admin.py
+++ b/tests/concepts/test_admin.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+""" Test cases for ModelAdmins in ddionrails.concepts app """
+
+import pytest
+from django.urls import reverse
+
+from tests import status
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_analyis_unit_admin_list(admin_client, analysis_unit):
+    """ Test the AnalysisUnitAdmin changelist """
+    url = reverse("admin:concepts_analysisunit_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_analyis_unit_admin_detail(admin_client, analysis_unit):
+    """ Test the AnalysisUnitAdmin change_view """
+    url = reverse("admin:concepts_analysisunit_change", args=(analysis_unit.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_concept_admin_list(admin_client, concept):
+    """ Test the ConceptAdmin changelist """
+    url = reverse("admin:concepts_concept_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_concept_admin_detail(admin_client, concept):
+    """ Test the ConceptAdmin change_view """
+    url = reverse("admin:concepts_concept_change", args=(concept.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_conceptual_dataset_admin_list(admin_client, conceptual_dataset):
+    """ Test the ConceptualDatasetAdmin changelist """
+    url = reverse("admin:concepts_conceptualdataset_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_conceptual_dataset_admin_detail(admin_client, conceptual_dataset):
+    """ Test the ConceptualDatasetAdmin change_view """
+    url = reverse(
+        "admin:concepts_conceptualdataset_change", args=(conceptual_dataset.id,)
+    )
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_period_admin_list(admin_client, period):
+    """ Test the PeriodAdmin changelist """
+    url = reverse("admin:concepts_period_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_period_admin_detail(admin_client, period):
+    """ Test the PeriodAdmin change_view """
+    url = reverse("admin:concepts_period_change", args=(period.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_topic_admin_list(admin_client, topic):
+    """ Test the TopicAdmin changelist """
+    url = reverse("admin:concepts_topic_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_topic_admin_detail(admin_client, topic):
+    """ Test the TopicAdmin change_view """
+    url = reverse("admin:concepts_topic_change", args=(topic.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from tests.concepts.factories import (
     PeriodFactory,
     TopicFactory,
 )
-from tests.data.factories import DatasetFactory, VariableFactory
+from tests.data.factories import DatasetFactory, TransformationFactory, VariableFactory
 from tests.factories import UserFactory
 from tests.instruments.factories import InstrumentFactory, QuestionFactory
 from tests.publications.factories import PublicationFactory
@@ -54,6 +54,12 @@ def variable(db):
     return VariableFactory(
         name="some-variable", label="Some Variable", description="This is some variable"
     )
+
+
+@pytest.fixture
+def transformation(db):
+    """ A transformation in the database """
+    return TransformationFactory()
 
 
 @pytest.fixture

--- a/tests/data/factories.py
+++ b/tests/data/factories.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+""" DjangoModelFactories for models in ddionrails.data app """
+
 import factory
 
 from ddionrails.data.models import Dataset, Transformation, Variable
@@ -14,14 +17,6 @@ class DatasetFactory(factory.django.DjangoModelFactory):
         django_get_or_create = ("study", "name")
 
 
-class TransformationFactory(factory.django.DjangoModelFactory):
-    """Transformation factory"""
-
-    class Meta:
-        model = Transformation
-        django_get_or_create = ("name",)
-
-
 class VariableFactory(factory.django.DjangoModelFactory):
     """Variable factory"""
 
@@ -30,3 +25,13 @@ class VariableFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Variable
         django_get_or_create = ("dataset", "name")
+
+
+class TransformationFactory(factory.django.DjangoModelFactory):
+    """Transformation factory"""
+
+    origin = factory.SubFactory(VariableFactory, name="some-origin-variable")
+    target = factory.SubFactory(VariableFactory, name="some-target-variable")
+
+    class Meta:
+        model = Transformation

--- a/tests/data/test_admin.py
+++ b/tests/data/test_admin.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+""" Test cases for ModelAdmins in ddionrails.data app """
+
+import pytest
+from django.urls import reverse
+
+from tests import status
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_dataset_admin_list(admin_client, dataset):
+    """ Test the DatasetAdmin changelist """
+    url = reverse("admin:data_dataset_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_dataset_admin_detail(admin_client, dataset):
+    """ Test the DatasetAdmin change_view """
+    url = reverse("admin:data_dataset_change", args=(dataset.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_variable_admin_list(admin_client, variable):
+    """ Test the VariableAdmin changelist """
+    url = reverse("admin:data_variable_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_variable_admin_detail(admin_client, variable):
+    """ Test the VariableAdmin change_view """
+    url = reverse("admin:data_variable_change", args=(variable.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_transformation_admin_list(admin_client, transformation):
+    """ Test the TransformationAdmin changelist """
+    url = reverse("admin:data_transformation_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_transformation_admin_detail(admin_client, transformation):
+    """ Test the TransformationAdmin change_view """
+    url = reverse("admin:data_transformation_change", args=(transformation.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code

--- a/tests/instruments/conftest.py
+++ b/tests/instruments/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from .factories import ConceptQuestionFactory, QuestionVariableFactory
+
 
 @pytest.fixture
 def invalid_instrument_data(study):
@@ -23,3 +25,15 @@ def invalid_question_data(instrument):
 def valid_question_data(instrument):
     """ A valid input for question forms and imports, relates to instrument fixture """
     return dict(question_name="some-question", instrument=instrument.pk)
+
+
+@pytest.fixture
+def concept_question(db):
+    """ A concept_question in the database """
+    return ConceptQuestionFactory()
+
+
+@pytest.fixture
+def question_variable(db):
+    """ A question_variable in the database """
+    return QuestionVariableFactory()

--- a/tests/instruments/factories.py
+++ b/tests/instruments/factories.py
@@ -1,6 +1,16 @@
+# -*- coding: utf-8 -*-
+""" DjangoModelFactories for models in ddionrails.instruments app """
+
 import factory
 
-from ddionrails.instruments.models import Instrument, Question
+from ddionrails.instruments.models import (
+    ConceptQuestion,
+    Instrument,
+    Question,
+    QuestionVariable,
+)
+from tests.concepts.factories import ConceptFactory
+from tests.data.factories import VariableFactory
 from tests.studies.factories import StudyFactory
 
 
@@ -22,3 +32,23 @@ class QuestionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Question
         django_get_or_create = ("instrument", "name")
+
+
+class ConceptQuestionFactory(factory.django.DjangoModelFactory):
+    """ConceptQuestion factory"""
+
+    concept = factory.SubFactory(ConceptFactory, name="some-concept")
+    question = factory.SubFactory(QuestionFactory, name="some-question")
+
+    class Meta:
+        model = ConceptQuestion
+
+
+class QuestionVariableFactory(factory.django.DjangoModelFactory):
+    """QuestionVariable factory"""
+
+    question = factory.SubFactory(QuestionFactory, name="some-question")
+    variable = factory.SubFactory(VariableFactory, name="some-variable")
+
+    class Meta:
+        model = QuestionVariable

--- a/tests/instruments/test_admin.py
+++ b/tests/instruments/test_admin.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+""" Test cases for ModelAdmins in ddionrails.instruments app """
+
+import pytest
+from django.urls import reverse
+
+from tests import status
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_instrument_admin_list(admin_client, instrument):
+    """ Test the InstrumentAdmin changelist """
+    url = reverse("admin:instruments_instrument_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_instrument_admin_detail(admin_client, instrument):
+    """ Test the InstrumentAdmin change_view """
+    url = reverse("admin:instruments_instrument_change", args=(instrument.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_question_admin_list(admin_client, question):
+    """ Test the QuestionAdmin changelist """
+    url = reverse("admin:instruments_question_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_question_admin_detail(admin_client, question):
+    """ Test the QuestionAdmin change_view """
+    url = reverse("admin:instruments_question_change", args=(question.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_concept_question_admin_list(admin_client, concept_question):
+    """ Test the ConceptQuestionAdmin changelist """
+    url = reverse("admin:instruments_conceptquestion_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_concept_question_admin_detail(admin_client, concept_question):
+    """ Test the ConceptQuestionAdmin change_view """
+    url = reverse("admin:instruments_conceptquestion_change", args=(concept_question.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_question_variable_admin_list(admin_client, question_variable):
+    """ Test the QuestionVariableAdmin changelist """
+    url = reverse("admin:instruments_questionvariable_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_question_variable_admin_detail(admin_client, question_variable):
+    """ Test the QuestionVariableAdmin change_view """
+    url = reverse("admin:instruments_questionvariable_change", args=(question_variable.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code

--- a/tests/publications/conftest.py
+++ b/tests/publications/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from .factories import AttachmentFactory
+
+
+@pytest.fixture
+def attachment(db):
+    """ An attachment in the database """
+    return AttachmentFactory(url="https://some-url.org")

--- a/tests/publications/factories.py
+++ b/tests/publications/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from ddionrails.publications.models import Publication
+from ddionrails.publications.models import Attachment, Publication
 from tests.studies.factories import StudyFactory
 
 
@@ -12,3 +12,12 @@ class PublicationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Publication
         django_get_or_create = ("name",)
+
+
+class AttachmentFactory(factory.django.DjangoModelFactory):
+    """Attachment factory"""
+
+    context_study = factory.SubFactory(StudyFactory, name="some-study")
+
+    class Meta:
+        model = Attachment

--- a/tests/publications/test_admin.py
+++ b/tests/publications/test_admin.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+""" Test cases for ModelAdmins in ddionrails.publications app """
+
+import pytest
+from django.urls import reverse
+
+from tests import status
+
+pytestmark = [pytest.mark.django_db]
+
+def test_attachment_admin_list(admin_client, attachment):
+    """ Test the AttachmentAdmin changelist """
+    url = reverse("admin:publications_attachment_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_attachment_admin_detail(admin_client, attachment):
+    """ Test the AttachmentAdmin change_view """
+    url = reverse("admin:publications_attachment_change", args=(attachment.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+def test_publication_admin_list(admin_client, publication):
+    """ Test the PublicationAdmin changelist """
+    url = reverse("admin:publications_publication_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_publication_admin_detail(admin_client, publication):
+    """ Test the PublicationAdmin change_view """
+    url = reverse("admin:publications_publication_change", args=(publication.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code

--- a/tests/studies/test_admin.py
+++ b/tests/studies/test_admin.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+""" Test cases for ModelAdmins in ddionrails.studies app """
+
+import pytest
+from django.urls import reverse
+from tests import status
+
+pytestmark = [pytest.mark.django_db]
+
+def test_study_admin_list(admin_client, study):
+    """ Test the StudyAdmin changelist """
+    url = reverse("admin:studies_study_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_study_admin_detail(admin_client, study):
+    """ Test the StudyAdmin change_view """
+    url = reverse("admin:studies_study_change", args=(study.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code

--- a/tests/workspace/conftest.py
+++ b/tests/workspace/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .factories import ScriptFactory
+from .factories import BasketVariableFactory, ScriptFactory
 
 
 @pytest.fixture
@@ -11,3 +11,9 @@ def script(db):
         label="Some Script",
         settings='{"analysis_unit": "some-analysis-unit"}',
     )
+
+
+@pytest.fixture
+def basket_variable(db):
+    """ A basket_variable in the database """
+    return BasketVariableFactory()

--- a/tests/workspace/factories.py
+++ b/tests/workspace/factories.py
@@ -1,6 +1,7 @@
 import factory
 
-from ddionrails.workspace.models import Basket, Script
+from ddionrails.workspace.models import Basket, BasketVariable, Script
+from tests.data.factories import VariableFactory
 from tests.factories import UserFactory
 from tests.studies.factories import StudyFactory
 
@@ -24,3 +25,14 @@ class ScriptFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Script
         django_get_or_create = ("name",)
+
+
+class BasketVariableFactory(factory.django.DjangoModelFactory):
+    """BasketVariable factory"""
+
+    basket = factory.SubFactory(BasketFactory, name="some-basket")
+    variable = factory.SubFactory(VariableFactory, name="some-variable")
+
+    class Meta:
+        model = BasketVariable
+        django_get_or_create = ("basket", "variable")

--- a/tests/workspace/test_admin.py
+++ b/tests/workspace/test_admin.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+""" Test cases for ModelAdmins in ddionrails.workspace app """
+
+import pytest
+from django.urls import reverse
+
+from tests import status
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_basket_variable_admin_list(admin_client, basket_variable):
+    """ Test the BasketVariableAdmin changelist """
+    url = reverse("admin:workspace_basketvariable_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_basket_variable_admin_detail(admin_client, basket_variable):
+    """ Test the BasketVariableAdmin change_view """
+    url = reverse("admin:workspace_basketvariable_change", args=(basket_variable.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_basket_admin_list(admin_client, basket):
+    """ Test the BasketAdmin changelist """
+    url = reverse("admin:workspace_basket_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_basket_admin_detail(admin_client, basket):
+    """ Test the BasketAdmin change_view """
+    url = reverse("admin:workspace_basket_change", args=(basket.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_script_admin_list(admin_client, script):
+    """ Test the ScriptAdmin changelist """
+    url = reverse("admin:workspace_script_changelist")
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code
+
+
+def test_script_admin_detail(admin_client, script):
+    """ Test the ScriptAdmin change_view """
+    url = reverse("admin:workspace_script_change", args=(script.id,))
+    response = admin_client.get(url)
+    assert status.HTTP_200_OK == response.status_code


### PR DESCRIPTION
## Proposed changes
This PR introduces the following changes to the code base:

- mount htmlcov as volume in docker-compose-dev.yml
- show django debug toolbar in development settings through nginx
- filtering options to ModelAdmins
- search fields in ModelAdmins
- annotated counts for related models in StudyAdmin
- improved performance for ModelAdmins by using `list_select_related` and `raw_id_fields`
- new factories
- new fixtures
- many more :smile:

Related issue(s): #440

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- Pytest passes locally with my changes
- I have added tests that prove my fix is effective or that my feature works