### PR TITLE
548: Remove get_answers method from Question

### DIFF
--- a/ddionrails/instruments/models/question.py
+++ b/ddionrails/instruments/models/question.py
@@ -97,9 +97,6 @@ class Question(ElasticMixin, DorMixin, models.Model):
     def layout_class(self) -> str:
         return "question"
 
-    def get_answers(self):
-        self.get_attribute["answers"]
-
     def previous_question(self):
         x = self.instrument.questions.get(sort_id=self.sort_id - 1)
         return x

--- a/tests/instruments/test_models.py
+++ b/tests/instruments/test_models.py
@@ -31,9 +31,6 @@ class TestQuestionModel:
         expected = "question"
         assert question.layout_class() == expected
 
-    def test_get_answers_method(self):
-        pass
-
     def test_previous_question_method(self):
         pass
 


### PR DESCRIPTION
## Proposed changes

- remove unused method Question.get_answers()

Related issue(s): #548

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes