### PR TITLE
545: Remove OS packages from Dockerfile

### DIFF
--- a/docker/ddionrails/Dockerfile
+++ b/docker/ddionrails/Dockerfile
@@ -20,11 +20,6 @@ RUN apk update \
         nodejs \
         nodejs-npm \
         postgresql-dev \
-        # pipenv did not want to build without these
-        gcc \
-        libffi-dev \
-        make \
-        musl-dev \
     && rm -rf /var/cache/apk/*
 
 RUN pip install --upgrade pipenv


### PR DESCRIPTION
## Proposed changes

Remove duplicated OS packages in Dockerfile.

Related issue(s): #545

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes
