### PR TITLE
546: Remove InheritanceManager from Instrument and Question

### DIFF
--- a/ddionrails/instruments/models/instrument.py
+++ b/ddionrails/instruments/models/instrument.py
@@ -3,7 +3,6 @@
 
 from django.db import models
 from django.urls import reverse
-from model_utils.managers import InheritanceManager
 
 from config.validators import validate_lowercase
 from ddionrails.base.mixins import ModelMixin as DorMixin
@@ -62,9 +61,6 @@ class Instrument(ElasticMixin, DorMixin, models.Model):
         on_delete=models.CASCADE,
         help_text="Foreign key to concepts.AnalysisUnit",
     )
-
-    # Custom Manager from model_utils.managers
-    objects = InheritanceManager()
 
     # Used by ElasticMixin when indexed into Elasticsearch
     DOC_TYPE = "instrument"

--- a/ddionrails/instruments/models/question.py
+++ b/ddionrails/instruments/models/question.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 from django.db import models
 from django.db.models import QuerySet
 from django.urls import reverse
-from model_utils.managers import InheritanceManager
 
 from config.validators import validate_lowercase
 from ddionrails.base.mixins import ModelMixin as DorMixin
@@ -61,9 +60,6 @@ class Question(ElasticMixin, DorMixin, models.Model):
         related_name="questions",
         on_delete=models.CASCADE,
     )
-
-    # Custom Manager from model_utils.managers
-    objects = InheritanceManager()
 
     # Used by ElasticMixin when indexed into Elasticsearch
     DOC_TYPE = "question"

--- a/ddionrails/instruments/views.py
+++ b/ddionrails/instruments/views.py
@@ -44,9 +44,8 @@ class InstrumentDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["instrument"] = self.object  # TODO: redundant
         context["study"] = self.object.study
-        context["questions"] = context["instrument"].questions.select_subclasses().all()
+        context["questions"] = context["instrument"].questions.all()
         return context
 
 

--- a/tests/instruments/test_views.py
+++ b/tests/instruments/test_views.py
@@ -1,9 +1,9 @@
+# -*- coding: utf-8 -*-
+
 import pytest
-from django.http.response import Http404
 from django.urls import reverse
 
 from ddionrails.elastic.mixins import ModelMixin
-from ddionrails.instruments.views import InstrumentRedirectView, QuestionRedirectView
 from tests import status
 
 pytestmark = [pytest.mark.django_db]
@@ -30,7 +30,7 @@ class TestInstrumentDetailView:
         assert template in (t.name for t in response.templates)
         assert response.context["instrument"] == instrument
         assert response.context["study"] == instrument.study
-        expected_questions = list(instrument.questions.select_subclasses().all())
+        expected_questions = list(instrument.questions.all())
         output_questions = list(response.context["questions"])
         assert expected_questions == output_questions
 


### PR DESCRIPTION
## Proposed changes

Remove unused custom ModelManager from django-model-utils from  Instrument and Question.

Related issue(s): #546

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes