### PR TITLE
Add port binding to docker-compose-dev.yml for elasticsearch service

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -21,7 +21,19 @@ services:
   postgres:
     env_file:
       - docker/environments/database.env.example
-    
+
+  elasticsearch:
+    ports:
+      - 9200:9200
+
+# Uncomment these lines, if you want to use Kibana
+#  kibana:
+#    image: kibana:4.6.0
+#    ports:
+#      - 5601:5601
+#    networks:
+#      - ddi_net
+
   nginx:
     volumes: 
       - ./docker/nginx/nginx.dev.conf:/etc/nginx/nginx.conf


### PR DESCRIPTION
## Proposed changes

Ads a port binding to the host for the elastic docker service in the docker-compose-dev.yml.
This enables manual inspection of elasticsearch during development.