### PR TITLE
[renovate] Add schedule to config

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
       "enabled": true
     },
     "rangeStrategy": "bump",
+    "schedule": "before 3am on Monday",
     "statusCheckVerify": true
   }
 }


### PR DESCRIPTION
## Proposed changes

Renovate sends single merge requests for updates, when it finds outdated versions.
This should bundle them to be delivered every Monday before work.