### PR TITLE
Bump Django version in README to 2.2.2 [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DDI on Rails
 
 [![Python version][python-badge]](https://www.python.org/downloads/release/python-373releases/)
-[![Django version][django-badge]](https://docs.djangoproject.com/en/2.2/releases/2.2.1/)
+[![Django version][django-badge]](https://docs.djangoproject.com/en/2.2/releases/2.2.2/)
 [![Repo license][license-badge]](https://www.gnu.org/licenses/agpl-3.0)
 
 [![Issues][issues-badge]](https://github.com/ddionrails/ddionrails/issues/)
@@ -95,7 +95,7 @@ This project is licensed under the GNU AGPL-3.0 License - see the [LICENSE.md](h
 <!-- Markdown link & img dfn's -->
 
 [python-badge]: https://img.shields.io/badge/Python-3.7.3-blue.svg
-[django-badge]: https://img.shields.io/badge/Django-2.2.1-blue.svg
+[django-badge]: https://img.shields.io/badge/Django-2.2.2-blue.svg
 [license-badge]: https://img.shields.io/badge/License-AGPL%20v3-blue.svg
 [reposize-badge]: https://img.shields.io/github/repo-size/badges/shields.svg
 [codecov-badge]: https://img.shields.io/codecov/c/github/ddionrails/ddionrails.svg


### PR DESCRIPTION
## Proposed changes

Bump Django version in README to 2.2.2

Related issue(s): None

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

N.A.