### PR TITLE
Add "npm run build" to package.json and Dockerfile

### DIFF
--- a/docker/ddionrails/Dockerfile
+++ b/docker/ddionrails/Dockerfile
@@ -30,8 +30,8 @@ RUN npm install
 RUN cd ./node_modules/ddionrails-elasticsearch \
     && npm install \
     && ./node_modules/.bin/ng build --prod
-RUN ./node_modules/.bin/webpack --config webpack.config.js
-RUN cp webpack-stats.json static/
+# Use webpack to bundle static files
+RUN npm run build
 
 # Set up entrypoint
 RUN mv docker/ddionrails/entrypoint.sh ${DOCKER_APP_DIRECTORY}/

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "webpack-bundle-tracker": "^0.4.2-beta",
     "webpack-cli": "^3.3.3"
   },
+  "scripts": {
+    "build": "webpack --config webpack.config.js"
+  },
   "renovate": {
     "baseBranches": [
       "develop"


### PR DESCRIPTION
## Proposed changes

- add scripts.build to package.json
- call `npm run build` in Dockerfile

Related issue(s): None

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- Pytest passes locally with my changes