### PR TITLE
588: Case sensitive names of Variable and Question

### DIFF
--- a/ddionrails/data/forms.py
+++ b/ddionrails/data/forms.py
@@ -40,8 +40,7 @@ class VariableForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.data["cs_name"] = self.data["variable_name"]
-        self.data["name"] = self.data["variable_name"].lower()
+        self.data["name"] = self.data["variable_name"]
         self.data["dataset"] = Dataset.get_or_create(
             dict(name=self.data["dataset_name"].lower(), study=self.data["study_object"])
         ).pk

--- a/ddionrails/data/imports.py
+++ b/ddionrails/data/imports.py
@@ -123,9 +123,7 @@ class VariableImport(imports.CSVImport):
         dataset = Dataset.objects.get(
             study=self.study, name=element["dataset_name"].lower()
         )
-        variable = Variable.objects.get(
-            dataset=dataset, name=element["variable_name"].lower()
-        )
+        variable = Variable.objects.get(dataset=dataset, name=element["variable_name"])
         concept_name = element.get("concept_name", "").lower()
         if concept_name != "":
             concept, status = Concept.objects.get_or_create(name=concept_name)

--- a/ddionrails/data/migrations/0001_initial.py
+++ b/ddionrails/data/migrations/0001_initial.py
@@ -95,14 +95,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                (
-                    "name",
-                    models.CharField(
-                        db_index=True,
-                        max_length=255,
-                        validators=[config.validators.validate_lowercase],
-                    ),
-                ),
+                ("name", models.CharField(db_index=True, max_length=255)),
                 ("label", models.CharField(blank=True, max_length=255)),
                 ("label_de", models.CharField(blank=True, max_length=255, null=True)),
                 ("description", models.TextField(blank=True)),

--- a/ddionrails/data/migrations/0002_auto_20190528_0827.py
+++ b/ddionrails/data/migrations/0002_auto_20190528_0827.py
@@ -204,10 +204,7 @@ class Migration(migrations.Migration):
             model_name="variable",
             name="name",
             field=models.CharField(
-                db_index=True,
-                help_text="Name of the variable (Lowercase)",
-                max_length=255,
-                validators=[config.validators.validate_lowercase],
+                db_index=True, help_text="Name of the variable", max_length=255
             ),
         ),
         migrations.AlterField(

--- a/ddionrails/data/migrations/0003_variable_image.py
+++ b/ddionrails/data/migrations/0003_variable_image.py
@@ -10,13 +10,18 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.FILER_IMAGE_MODEL),
-        ('data', '0002_auto_20190528_0827'),
+        ("data", "0002_auto_20190528_0827"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='variable',
-            name='image',
-            field=filer.fields.image.FilerImageField(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.FILER_IMAGE_MODEL),
-        ),
+            model_name="variable",
+            name="image",
+            field=filer.fields.image.FilerImageField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to=settings.FILER_IMAGE_MODEL,
+            ),
+        )
     ]

--- a/ddionrails/data/migrations/0004_auto_20190614_1514.py
+++ b/ddionrails/data/migrations/0004_auto_20190614_1514.py
@@ -6,24 +6,34 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('data', '0003_variable_image'),
-    ]
+    dependencies = [("data", "0003_variable_image")]
 
     operations = [
         migrations.AddField(
-            model_name='variable',
-            name='categories',
-            field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=list, help_text='Categories of the variable(JSON)', null=True),
+            model_name="variable",
+            name="categories",
+            field=django.contrib.postgres.fields.jsonb.JSONField(
+                blank=True,
+                default=list,
+                help_text="Categories of the variable(JSON)",
+                null=True,
+            ),
         ),
         migrations.AddField(
-            model_name='variable',
-            name='scale',
-            field=models.CharField(blank=True, help_text='Scale of the variable', max_length=255),
+            model_name="variable",
+            name="scale",
+            field=models.CharField(
+                blank=True, help_text="Scale of the variable", max_length=255
+            ),
         ),
         migrations.AddField(
-            model_name='variable',
-            name='statistics',
-            field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, help_text='Statistics of the variable(JSON)', null=True),
+            model_name="variable",
+            name="statistics",
+            field=django.contrib.postgres.fields.jsonb.JSONField(
+                blank=True,
+                default=dict,
+                help_text="Statistics of the variable(JSON)",
+                null=True,
+            ),
         ),
     ]

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -13,7 +13,6 @@ from django.urls import reverse
 from filer.fields.image import FilerImageField
 
 from config.helpers import render_markdown
-from config.validators import validate_lowercase
 from ddionrails.base.mixins import ModelMixin as DorMixin
 from ddionrails.concepts.models import Concept, Period
 from ddionrails.elastic.mixins import ModelMixin as ElasticMixin
@@ -30,10 +29,7 @@ class Variable(ElasticMixin, DorMixin, models.Model):
 
     # attributes
     name = models.CharField(
-        max_length=255,
-        validators=[validate_lowercase],
-        db_index=True,
-        help_text="Name of the variable (Lowercase)",
+        max_length=255, db_index=True, help_text="Name of the variable"
     )
     label = models.CharField(
         max_length=255,
@@ -71,10 +67,7 @@ class Variable(ElasticMixin, DorMixin, models.Model):
         default=dict, null=True, blank=True, help_text="Statistics of the variable(JSON)"
     )
     scale = models.CharField(
-        max_length=255,
-        null=True,
-        blank=True,
-        help_text="Scale of the variable",
+        max_length=255, null=True, blank=True, help_text="Scale of the variable"
     )
     categories = JSONBField(
         default=list, null=True, blank=True, help_text="Categories of the variable(JSON)"
@@ -169,10 +162,6 @@ class Variable(ElasticMixin, DorMixin, models.Model):
             return categories
         else:
             return []
-
-    def get_name_cs(self):
-        """Get the case sensitive version of the variable name, if available"""
-        return self.get_source().get("name_cs", self.name)
 
     def get_study(self, default=None, id=False):
         try:

--- a/ddionrails/instruments/forms.py
+++ b/ddionrails/instruments/forms.py
@@ -28,7 +28,7 @@ class QuestionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.data["name"] = self.data["question_name"].lower()
+        self.data["name"] = self.data["question_name"]
         self._set_instrument()
 
     def _set_instrument(self):

--- a/ddionrails/instruments/imports.py
+++ b/ddionrails/instruments/imports.py
@@ -2,7 +2,6 @@ import json
 import logging
 from collections import OrderedDict
 
-from config.helpers import lower_dict_names
 from ddionrails.concepts.models import Concept, Period
 from ddionrails.data.models import Variable
 from ddionrails.imports import imports
@@ -62,7 +61,6 @@ class QuestionVariableImport(imports.CSVImport):
 
     def _import_link(self, link):
         try:
-            lower_dict_names(link)
             question = self._get_question(link)
             variable = self._get_variable(link)
             qv_link = QuestionVariable.objects.get_or_create(
@@ -102,7 +100,6 @@ class ConceptQuestionImport(imports.CSVImport):
 
     def _import_link(self, link):
         try:
-            lower_dict_names(link)
             question = self._get_question(link)
             concept = self._get_concept(link)
             qv_link = ConceptQuestion.objects.get_or_create(

--- a/ddionrails/instruments/migrations/0001_initial.py
+++ b/ddionrails/instruments/migrations/0001_initial.py
@@ -90,14 +90,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                (
-                    "name",
-                    models.CharField(
-                        db_index=True,
-                        max_length=255,
-                        validators=[config.validators.validate_lowercase],
-                    ),
-                ),
+                ("name", models.CharField(db_index=True, max_length=255)),
                 ("label", models.CharField(blank=True, max_length=255)),
                 ("label_de", models.CharField(blank=True, max_length=255)),
                 ("description", models.TextField(blank=True)),

--- a/ddionrails/instruments/migrations/0003_auto_20190528_0801.py
+++ b/ddionrails/instruments/migrations/0003_auto_20190528_0801.py
@@ -127,10 +127,7 @@ class Migration(migrations.Migration):
             model_name="question",
             name="name",
             field=models.CharField(
-                db_index=True,
-                help_text="Name of the question (Lowercase)",
-                max_length=255,
-                validators=[config.validators.validate_lowercase],
+                db_index=True, help_text="Name of the question", max_length=255
             ),
         ),
         migrations.AlterField(

--- a/ddionrails/instruments/models/question.py
+++ b/ddionrails/instruments/models/question.py
@@ -13,7 +13,6 @@ from django.db import models
 from django.db.models import QuerySet
 from django.urls import reverse
 
-from config.validators import validate_lowercase
 from ddionrails.base.mixins import ModelMixin as DorMixin
 from ddionrails.concepts.models import Concept
 from ddionrails.elastic.mixins import ModelMixin as ElasticMixin
@@ -29,10 +28,7 @@ class Question(ElasticMixin, DorMixin, models.Model):
 
     # attributes
     name = models.CharField(
-        max_length=255,
-        validators=[validate_lowercase],
-        db_index=True,
-        help_text="Name of the question (Lowercase)",
+        max_length=255, db_index=True, help_text="Name of the question"
     )
     label = models.TextField(
         blank=True,
@@ -172,13 +168,6 @@ class Question(ElasticMixin, DorMixin, models.Model):
     def concept_list(self):
         """DEPRECATED NAME"""
         return self.get_concepts()
-
-    def get_cs_name(self):
-        x = self.get_source().get("question", "")
-        if x != "":
-            return x
-        else:
-            return self.name
 
     def title(self):
         if self.label != None and self.label != "":

--- a/templates/data/variable_info.html
+++ b/templates/data/variable_info.html
@@ -4,8 +4,8 @@
   </div>
   <div class="panel-body">
     <p>
-      <b>Variable name (case sensitive):</b>
-      <a href="{{ variable }}">{{ variable.get_name_cs }}</a>
+      <b>Variable name:</b>
+      <a href="{{ variable }}">{{ variable.name }}</a>
     </p>
     <p>
       <b>Dataset:</b>

--- a/templates/questions/question_detail.html
+++ b/templates/questions/question_detail.html
@@ -21,7 +21,7 @@ $(function(){
   <div class="col-md-9">
     <div class="panel panel-default">
       <div class="panel-body">
-        <h2 class="text-center">{{ question.get_cs_name }}</h2>
+        <h2 class="text-center">{{ question.name }}</h2>
         <p>{{ question.description }}</p>
         <hr />
         {% for item in question.item_array %}


### PR DESCRIPTION
## Proposed changes

- remove validate_lowercase validator from Question.name
- remove get_cs_name() method from Question
- remove lower() in QuestionForm
- remove lower_dict_names in Question related imports
- remove get_cs_name() call in template question_detail.html
- remove validate_lowercase validator from Variable.name
- remove get_name_cs() method from Variable
- remove lower() in VariableForm
- remove "cs_name" in VariableForm
- remove lower() in Variable related imports
- remove get_name_cs() call in template variable_info.html

Related issue(s): #588

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- Pytest passes locally with my changes
