### PR TITLE
[tests] Reorder fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@
 
 """ Pytest fixtures """
 
+from io import BytesIO
+
+import PIL.Image
 import pytest
 
 from tests.base.factories import SystemFactory
@@ -22,22 +25,13 @@ from tests.workspace.factories import BasketFactory
 
 
 @pytest.fixture
-def system(db):
-    """ A system model in the database """
-    return SystemFactory()
-
-
-@pytest.fixture
-def study(db):
-    """ A study in the database """
-    return StudyFactory(name="some-study", label="Some Study")
-
-
-@pytest.fixture
-def user(db):
-    """ A user in the database """
-    # ignore B106: hardcoded_password_funcarg
-    return UserFactory(username="some-user", password="some-password")  # nosec
+def analysis_unit(db):
+    """ An analysis unit in the database """
+    return AnalysisUnitFactory(
+        name="some-analysis-unit",
+        label="Some analysis unit",
+        description="This is some analysis unit",
+    )
 
 
 @pytest.fixture
@@ -47,11 +41,132 @@ def basket(study, user):
 
 
 @pytest.fixture
+def concept(db):
+    """ A concept in the database """
+    return ConceptFactory(
+        name="some-concept", label="Some Concept", description="This is some concept"
+    )
+
+
+@pytest.fixture
+def conceptual_dataset(db):
+    """ A conceptual dataset in the database """
+    return ConceptualDatasetFactory(
+        name="some-conceptual-dataset",
+        label="Some conceptual dataset",
+        description="This is some conceptualdataset",
+    )
+
+
+@pytest.fixture
 def dataset(db):
     """ A dataset in the database """
     return DatasetFactory(
         name="some-dataset", label="Some Dataset", description="This is some dataset"
     )
+
+
+@pytest.fixture()
+def empty_data():
+    """ Empty dictionary is used as invalid data for form and import tests """
+    return {}
+
+
+@pytest.fixture()
+def image_file(request) -> BytesIO:
+    """ Provides an in memory image file. """
+    _file = BytesIO()
+    _image = PIL.Image.new("RGBA", size=(700, 100))
+    _image.save(_file, "png")
+    _file.name = "test.png"
+    _file.seek(0)
+    if request.instance:
+        request.instance.image_file = _file
+    yield _file
+    _file = None
+
+
+@pytest.fixture
+def instrument(db):
+    """ An instrument in the database """
+    return InstrumentFactory(
+        name="some-instrument",
+        label="Some Instrument",
+        description="This is some instrument",
+    )
+
+
+@pytest.fixture
+def period(db):
+    """ A period in the database """
+    return PeriodFactory(
+        name="some-period",
+        label="Some period",
+        description="This is some period",
+        definition="2018",
+    )
+
+
+@pytest.fixture
+def publication(study):
+    """ A publication in the database, relates to study fixture """
+    return PublicationFactory(name="some-publication", study=study)
+
+
+@pytest.fixture
+def question(db, request):
+    """ A question in the database """
+    question = QuestionFactory(
+        name="some-question",
+        label="Some Question",
+        description="This is some question",
+        sort_id=1,
+    )
+    # To work with unittest
+    if request.instance:
+        request.instance.question = question
+    return question
+
+
+@pytest.fixture
+def study(db):
+    """ A study in the database """
+    return StudyFactory(name="some-study", label="Some Study")
+
+
+@pytest.fixture
+def system(db):
+    """ A system model in the database """
+    return SystemFactory()
+
+
+@pytest.fixture
+def topic(db):
+    """ A topic in the database """
+    return TopicFactory(name="some-topic")
+
+
+@pytest.fixture
+def topiclist(db):
+    """ A topiclist in the database """
+    body = [
+        {"language": "en", "topics": [{"title": "some-topic"}]},
+        {"language": "de", "topics": [{"title": "some-german-topic"}]},
+    ]
+    return TopicListFactory(topiclist=body)
+
+
+@pytest.fixture
+def transformation(db):
+    """ A transformation in the database """
+    return TransformationFactory()
+
+
+@pytest.fixture
+def user(db):
+    """ A user in the database """
+    # ignore B106: hardcoded_password_funcarg
+    return UserFactory(username="some-user", password="some-password")  # nosec
 
 
 @pytest.fixture
@@ -77,105 +192,3 @@ def variable(db):
             "missings": [True, False],
         },
     )
-
-
-@pytest.fixture
-def transformation(db):
-    """ A transformation in the database """
-    return TransformationFactory()
-
-
-@pytest.fixture
-def instrument(db):
-    """ An instrument in the database """
-    return InstrumentFactory(
-        name="some-instrument",
-        label="Some Instrument",
-        description="This is some instrument",
-    )
-
-
-@pytest.fixture()
-def empty_data():
-    """ Empty dictionary is used as invalid data for form and import tests """
-    return {}
-
-
-@pytest.fixture
-def concept(db):
-    """ A concept in the database """
-    return ConceptFactory(
-        name="some-concept", label="Some Concept", description="This is some concept"
-    )
-
-
-@pytest.fixture
-def publication(study):
-    """ A publication in the database, relates to study fixture """
-    return PublicationFactory(name="some-publication", study=study)
-
-
-@pytest.fixture
-def question(db, request):
-    """ A question in the database """
-    # To work with unittest
-    if request.instance:
-        request.instance.question = QuestionFactory(
-            name="some-question",
-            label="Some Question",
-            description="This is some question",
-            sort_id=1,
-        )
-    return QuestionFactory(
-        name="some-question",
-        label="Some Question",
-        description="This is some question",
-        sort_id=1,
-    )
-
-
-@pytest.fixture
-def analysis_unit(db):
-    """ An analysis unit in the database """
-    return AnalysisUnitFactory(
-        name="some-analysis-unit",
-        label="Some analysis unit",
-        description="This is some analysis unit",
-    )
-
-
-@pytest.fixture
-def conceptual_dataset(db):
-    """ A conceptual dataset in the database """
-    return ConceptualDatasetFactory(
-        name="some-conceptual-dataset",
-        label="Some conceptual dataset",
-        description="This is some conceptualdataset",
-    )
-
-
-@pytest.fixture
-def period(db):
-    """ A period in the database """
-    return PeriodFactory(
-        name="some-period",
-        label="Some period",
-        description="This is some period",
-        definition="2018",
-    )
-
-
-@pytest.fixture
-def topic(db):
-    """ A topic in the database """
-    return TopicFactory(name="some-topic")
-
-
-@pytest.fixture
-def topiclist(db):
-    """ A topiclist in the database """
-    body = [
-        {"language": "en", "topics": [{"title": "some-topic"}]},
-        {"language": "de", "topics": [{"title": "some-german-topic"}]},
-    ]
-    return TopicListFactory(topiclist=body)

--- a/tests/instruments/test_models.py
+++ b/tests/instruments/test_models.py
@@ -6,7 +6,6 @@
 import unittest
 from io import BytesIO
 
-import PIL.Image
 import pytest
 from django.core.files import File
 from django.db import models
@@ -170,16 +169,3 @@ class TestQuestionImageModel(unittest.TestCase):
         image.language = "de"
         image.save()
         return image
-
-
-@pytest.fixture()
-def image_file(request) -> BytesIO:
-    _file = BytesIO()
-    _image = PIL.Image.new("RGBA", size=(700, 100))
-    _image.save(_file, "png")
-    _file.name = "test.png"
-    _file.seek(0)
-    if request.instance:
-        request.instance.image_file = _file
-    yield _file
-    _file = None


### PR DESCRIPTION
- Move Image fixture from tests.instruments.test_models to tests.conftest.
- Order fixtures in tests.conftest alphabetically.