### PR TITLE
618: Move context from ddionrails.studies.models into own module

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -104,7 +104,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-                "ddionrails.studies.models.context",
+                "ddionrails.studies.context_processors.studies_processor",
             ]
         },
     }

--- a/ddionrails/studies/context_processors.py
+++ b/ddionrails/studies/context_processors.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+""" Context Processors for ddionrails.studies app """
+
+from typing import Dict
+
+from django.core.handlers.wsgi import WSGIRequest
+from django.db.models.query import QuerySet
+
+from .models import Study
+
+
+# request is a required parameter
+def studies_processor(
+    request: WSGIRequest
+) -> Dict[str, QuerySet]:  # pylint: disable=unused-argument
+    """ Context processor returns all studies in a dictionary """
+
+    return dict(studies=Study.objects.all().only("name", "label"))

--- a/ddionrails/studies/models.py
+++ b/ddionrails/studies/models.py
@@ -133,7 +133,3 @@ class Study(ModelMixin, TimeStampedModel):
                     return topiclist.get("topics")
         except TopicList.DoesNotExist:
             return None
-
-
-def context(request):
-    return dict(all_studies=Study.objects.all().only("name", "label", "description"))

--- a/templates/nav/home.html
+++ b/templates/nav/home.html
@@ -6,7 +6,7 @@
     <span class="sr-only">Toggle Dropdown</span>
   </button>
   <ul class="dropdown-menu">
-    {% for study in all_studies %}
+    {% for study in studies %}
         <li><a href="/study/{{ study.id }}">{{ study.title }}</a></li>
     {% endfor %}
   </ul>

--- a/tests/studies/test_context_processors.py
+++ b/tests/studies/test_context_processors.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring,no-self-use,too-few-public-methods
+
+""" Test cases for ddionrails.studies.context_processors """
+
+import pytest
+
+from ddionrails.studies.context_processors import studies_processor
+from ddionrails.studies.models import Study
+
+pytestmark = [pytest.mark.studies]  # pylint: disable=invalid-name
+
+
+def test_studies_processor_with_study(study, rf):  # pylint: disable=invalid-name
+    some_request = rf.get("/")
+    response = studies_processor(some_request)
+    queryset = Study.objects.all()
+    expected = dict(studies=queryset)
+    assert list(expected["studies"]) == list(response["studies"])
+
+
+@pytest.mark.django_db
+def test_studies_processor_without_study(rf):  # pylint: disable=invalid-name
+    some_request = rf.get("/")
+    response = studies_processor(some_request)
+    empty_queryset = Study.objects.none()
+    expected = dict(studies=empty_queryset)
+    assert list(expected["studies"]) == list(response["studies"])

--- a/tests/studies/test_models.py
+++ b/tests/studies/test_models.py
@@ -7,7 +7,7 @@ import pathlib
 
 import pytest
 
-from ddionrails.studies.models import Study, TopicList, context
+from ddionrails.studies.models import TopicList
 
 pytestmark = [pytest.mark.studies, pytest.mark.models]  # pylint: disable=invalid-name
 
@@ -82,17 +82,3 @@ class TestStudyModel:
         result = study.get_topiclist()
         expected = None
         assert expected is result
-
-
-def test_context_function_with_study(study, rf):
-    some_request = rf.get("/")
-    response = context(some_request)
-    queryset = Study.objects.filter(id=study.id)
-    assert str(response) == str({"all_studies": queryset})
-
-
-def test_context_function_without_study(rf, db):
-    some_request = rf.get("/")
-    response = context(some_request)
-    empty_queryset = Study.objects.none()
-    assert str(response) == str({"all_studies": empty_queryset})


### PR DESCRIPTION
## Proposed changes

- move context() into context_processors.py
- update settings
- update template
- update test cases

Related issue(s): #618

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes
