### PR TITLE
Add test case for config/settings/base.py

### DIFF
--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring,invalid-name
+
+""" Test cases for settings of ddionrails project """
+
+from importlib import reload
+
+
+def test_django_debug_settings(monkeypatch):
+    monkeypatch.setenv("DJANGO_DEBUG", "True")
+    from config.settings import base as settings
+
+    expected = True
+    assert expected is settings.DEBUG
+    expected = (str(settings.BASE_DIR.joinpath("static")),)
+    assert expected == settings.STATICFILES_DIRS
+    expected = False
+    assert expected is hasattr(settings, "STATIC_ROOT")
+
+
+def test_django_debug_settings_false(monkeypatch):
+    monkeypatch.setenv("DJANGO_DEBUG", "False")
+    monkeypatch.setenv("STATIC_ROOT", "static")
+
+    from config.settings import base as settings
+
+    settings = reload(settings)
+    expected = False
+    assert expected is settings.DEBUG
+    expected = "static"
+    assert expected == settings.STATIC_ROOT


### PR DESCRIPTION
## Proposed changes

This PR adds two test cases to ensure the Django base settings set the variables, from environment variables correctly.

Related issue(s): None

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes
