### PR TITLE
651: data.Variable.get_categories() deals with missing "labels_de"

### DIFF
--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -149,16 +149,16 @@ class Variable(ElasticMixin, DorMixin, models.Model):
     def get_categories(self) -> List:
         if self.categories:
             categories = []
-            for index in range(len(self.categories["values"])):
-                categories.append(
-                    dict(
-                        value=self.categories["values"][index],
-                        label=self.categories["labels"][index],
-                        label_de=self.categories["labels_de"][index],
-                        frequency=self.categories["frequencies"][index],
-                        valid=(not self.categories["missings"][index]),
-                    )
+            for index, _ in enumerate(self.categories["values"]):
+                category = dict(
+                    value=self.categories["values"][index],
+                    label=self.categories["labels"][index],
+                    frequency=self.categories["frequencies"][index],
+                    valid=(not self.categories["missings"][index]),
                 )
+                if "labels_de" in self.categories:
+                    category["label_de"] = self.categories["labels_de"][index]
+                categories.append(category)
             return categories
         else:
             return []

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -94,6 +94,18 @@ class TestVariableModel:
         }
         assert expected == result[0]
 
+    def test_get_categories_method_without_labels_de(self, variable):
+        variable.categories.pop("labels_de")
+        variable.save()
+        result = variable.get_categories()
+        expected = {
+            "value": "-6",
+            "label": "[-6] Version of questionnaire with modified filtering",
+            "frequency": 1,
+            "valid": False,
+        }
+        assert expected == result[0]
+
     def test_is_categorical_method(self, variable):
         variable.categories = [dict(label="some-category")]
         variable.save()


### PR DESCRIPTION
## Proposed changes

This PR introduces the following changes:
- data.Variable.get_categories() does not throw KeyError when trying to access missing "labels_de" key in "categories"
- add test case

Related issue(s): #651

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- I have added tests that prove my fix is effective or that my feature works