### PR TITLE
Ignore RemovedInDjango30Warning in tests/data/test_admin.py

### DIFF
--- a/tests/data/test_admin.py
+++ b/tests/data/test_admin.py
@@ -6,7 +6,13 @@ from django.urls import reverse
 
 from tests import status
 
-pytestmark = [pytest.mark.django_db]  # pylint: disable=invalid-name
+# One of the admin views in django itself
+# uses {% load staticfiles %} instead {% load static %}.
+# It throws a "django.utils.deprecation.RemovedInDjango30Warning"
+pytestmark = [  # pylint: disable=invalid-name
+    pytest.mark.django_db,
+    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
+]
 
 
 def test_dataset_admin_list(admin_client, dataset):  # pylint: disable=unused-argument


### PR DESCRIPTION
## Proposed changes

Django itself uses {% load staticfiles %} instead of {% load static %} in some admin views. This throws some RemovedInDjango30Warnings in the test runs. I propose to ignore this warning in the affected test module.

Related issue(s): None

## Types of changes

- Bugfix (non-breaking change which fixes an issue)


## Checklist

- Pytest passes locally with my changes