### PR TITLE
666: Add "description_de" fields to all models

### DIFF
--- a/ddionrails/concepts/models.py
+++ b/ddionrails/concepts/models.py
@@ -52,8 +52,13 @@ class Topic(models.Model, ModelMixin):
     )
     description = models.TextField(
         blank=True,
-        verbose_name="Description (Markdown)",
-        help_text="Description of the topic (Markdown)",
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the topic (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the topic (Markdown, German)",
     )
 
     #############
@@ -141,8 +146,13 @@ class Concept(models.Model, ModelMixin, ElasticMixin):
     )
     description = models.TextField(
         blank=True,
-        verbose_name="Description (Markdown)",
-        help_text="Description of the concept (Markdown)",
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the concept (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the concept (Markdown, German)",
     )
 
     #############
@@ -340,8 +350,13 @@ class AnalysisUnit(models.Model, ModelMixin):
     )
     description = models.TextField(
         blank=True,
-        verbose_name="Description (Markdown)",
-        help_text="Description of the analysis unit (Markdown)",
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the analysis unit (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the analysis unit (Markdown, German)",
     )
 
     def __str__(self) -> str:
@@ -410,8 +425,13 @@ class ConceptualDataset(models.Model, ModelMixin):
     )
     description = models.TextField(
         blank=True,
-        verbose_name="Description (Markdown)",
-        help_text="Description of the conceptual dataset (Markdown)",
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the conceptual dataset (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the conceptual dataset (Markdown, German)",
     )
 
     def __str__(self) -> str:

--- a/ddionrails/data/models/dataset.py
+++ b/ddionrails/data/models/dataset.py
@@ -47,12 +47,17 @@ class Dataset(ModelMixin, models.Model):
         blank=True,
         null=True,
         verbose_name="Label (German)",
-        help_text="Label of the dataset (German",
+        help_text="Label of the dataset (German)",
     )
     description = models.TextField(
         blank=True,
-        verbose_name="Description (Markdown)",
-        help_text="Description of the dataset (Markdown)",
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the dataset (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the dataset (Markdown, German)",
     )
     boost = models.FloatField(
         blank=True,

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -60,8 +60,13 @@ class Variable(ElasticMixin, DorMixin, models.Model):
     )
     description = models.TextField(
         blank=True,
-        verbose_name="Description (Markdown)",
-        help_text="Description of the variable (Markdown)",
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the variable (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the variable (Markdown, German)",
     )
     description_long = models.TextField(
         blank=True,

--- a/ddionrails/instruments/models/instrument.py
+++ b/ddionrails/instruments/models/instrument.py
@@ -50,8 +50,13 @@ class Instrument(ModelMixin, models.Model):
     )
     description = models.TextField(
         blank=True,
-        verbose_name="Description (Markdown)",
-        help_text="Description of the topic (Markdown)",
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the instrument (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the instrument (Markdown, German)",
     )
 
     #############

--- a/ddionrails/instruments/models/question.py
+++ b/ddionrails/instruments/models/question.py
@@ -55,8 +55,13 @@ class Question(ElasticMixin, DorMixin, models.Model):
     )
     description = models.TextField(
         blank=True,
-        verbose_name="Description (Markdown)",
-        help_text="Description of the topic (Markdown)",
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the question (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the question (Markdown, German)",
     )
     sort_id = models.IntegerField(
         blank=True,

--- a/ddionrails/studies/models.py
+++ b/ddionrails/studies/models.py
@@ -76,7 +76,14 @@ class Study(ImportPathMixin, ModelMixin, TimeStampedModel):
         help_text="Label of the study (German)",
     )
     description = models.TextField(
-        blank=True, help_text="Description of the study (Markdown)"
+        blank=True,
+        verbose_name="Description (Markdown, English)",
+        help_text="Description of the study (Markdown, English)",
+    )
+    description_de = models.TextField(
+        blank=True,
+        verbose_name="Description (Markdown, German)",
+        help_text="Description of the study (Markdown, German)",
     )
     doi = models.CharField(
         max_length=255,


### PR DESCRIPTION
## Proposed changes
Add `description_de` field to:
- Topic
- Concept
- AnalysisUnit
- ConceptualDataset
- Dataset
- Variable
- Instrument
- Question
- Study

Related issue(s): #666

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes

## Further comments

Migration files are not part of this PR.