### PR TITLE
667: Decouple importing metadata into database and search engine

### DIFF
--- a/ddionrails/concepts/models.py
+++ b/ddionrails/concepts/models.py
@@ -190,31 +190,6 @@ class Concept(models.Model, ModelMixin, ElasticMixin):
         """ Returns a canonical URL for the model using the "name" field """
         return reverse("concepts:concept_detail_name", kwargs={"concept_name": self.name})
 
-    def index(self) -> None:
-        """ Indexes the concept in Elasticsearch (name, label and related study) """
-        if self.label and self.label != "":
-            label = self.label
-        else:
-            try:
-                label = self.variables.first().label
-            except AttributeError:
-                label = ""
-        study = list(
-            {
-                s.name
-                for s in Study.objects.filter(
-                    datasets__variables__concept_id=self.id
-                ).all()
-            }
-        )
-        self.set_elastic(dict(name=self.name, label=label, study=study))
-
-    @classmethod
-    def index_all(cls) -> None:
-        """ Indexes all concepts in Elasticsearch using the index method """
-        for concept in cls.objects.all():
-            concept.index()
-
 
 class Period(models.Model, ModelMixin):
     """

--- a/ddionrails/data/imports.py
+++ b/ddionrails/data/imports.py
@@ -58,15 +58,6 @@ class DatasetJsonImport(imports.Import):
                 variable.categories = var["categories"]
         variable.scale = var.get("scale", "")
         variable.save()
-        # remove statistics and scale before indexing into elasticsearch
-        var.pop("statistics", None)
-        var.pop("scale", None)
-        # Used for searching right now
-        # var.pop("categories", None)
-        var["namespace"] = self.study.name
-        var["dataset"] = dataset.name
-        var["boost"] = dataset.boost
-        variable.set_elastic(var)
 
 
 class DatasetImport(imports.CSVImport):

--- a/ddionrails/imports/management/commands/index.py
+++ b/ddionrails/imports/management/commands/index.py
@@ -7,7 +7,13 @@ import pathlib
 
 import djclick as click
 from django.conf import settings
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, helpers
+
+from ddionrails.concepts.models import Concept
+from ddionrails.data.models import Variable
+from ddionrails.instruments.models import Question
+from ddionrails.publications.models import Publication
+from ddionrails.studies.models import Study
 
 elasticsearch_client = Elasticsearch(hosts=[settings.INDEX_HOST])
 
@@ -71,6 +77,131 @@ def reset(mapping_file: str) -> None:
     create(mapping_file)
 
 
+def concepts():
+    """ Iterate over all concepts in the database """
+
+    queryset = Concept.objects.prefetch_related("variables").all()
+    for concept in queryset:
+        study = list(
+            Study.objects.filter(datasets__variables__concept_id=concept.id)
+            .values_list("name", flat=True)
+            .distinct()
+        )
+        yield {
+            "_index": settings.INDEX_NAME,
+            "_type": concept.DOC_TYPE,
+            "_id": str(concept.id),
+            "_source": {"name": concept.name, "label": concept.label, "study": study},
+        }
+
+
+def publications():
+    """ Iterate over all publications in the database """
+
+    queryset = Publication.objects.select_related("study").all()
+    for publication in queryset:
+        yield {
+            "_index": settings.INDEX_NAME,
+            "_type": publication.DOC_TYPE,
+            "_id": str(publication.id),
+            "_source": publication.to_elastic_dict(),
+        }
+
+
+def questions():
+    """ Iterate over all questions in the database """
+
+    queryset = Question.objects.select_related(
+        "instrument",
+        "instrument__analysis_unit",
+        "instrument__period",
+        "instrument__study",
+    ).all()
+    for question in queryset:
+        period = question.get_period(period_id="name")
+        try:
+            analysis_unit = question.instrument.analysis_unit.name
+        except AttributeError:
+            analysis_unit = None
+        yield {
+            "_index": settings.INDEX_NAME,
+            "_type": question.DOC_TYPE,
+            "_id": str(question.id),
+            "_source": {
+                "period": period,
+                "analysis_unit": analysis_unit,
+                "question": question.name,
+                "name": question.name,
+                "label": question.label,
+                "items": question.items,
+                "sort_id": question.sort_id,
+                "instrument": question.instrument.name,
+                "study": question.instrument.study.name,
+                "namespace": question.instrument.study.name,
+            },
+        }
+
+
+def variables():
+    """ Iterate over all variables in the database """
+
+    queryset = Variable.objects.select_related(
+        "dataset",
+        "dataset__study",
+        "dataset__analysis_unit",
+        "dataset__conceptual_dataset",
+        "dataset__period",
+    ).all()
+    for variable in queryset:
+        period = variable.get_period(period_id="name")
+        try:
+            analysis_unit = variable.dataset.analysis_unit.name
+        except AttributeError:
+            analysis_unit = None
+        try:
+            sub_type = variable.dataset.conceptual_dataset.name
+        except AttributeError:
+            sub_type = None
+
+        yield {
+            "_index": settings.INDEX_NAME,
+            "_type": variable.DOC_TYPE,
+            "_id": str(variable.id),
+            "_source": {
+                "name": variable.name,
+                "variable": variable.name,
+                "label": variable.label,
+                "label_de": variable.label_de,
+                "dataset": variable.dataset.name,
+                "period": period,
+                "sub_type": sub_type,
+                "analysis_unit": analysis_unit,
+                "study": variable.dataset.study.name,
+                "namespace": variable.dataset.study.name,
+                "categories": variable.categories,
+            },
+        }
+
+
+def populate():
+    """ Workaround """
+    print(f"Indexing {Publication.objects.count()} publications into Elasticsearch")
+    result = helpers.bulk(elasticsearch_client, publications())
+    print(result)
+
+    print(f"Indexing {Concept.objects.count()} concepts into Elasticsearch")
+    result = helpers.bulk(elasticsearch_client, concepts())
+    print(result)
+
+    print(f"Indexing {Question.objects.count()} questions into Elasticsearch")
+    result = helpers.bulk(elasticsearch_client, questions())
+    print(result)
+
+    print(f"Indexing {Variable.objects.count()} variables into Elasticsearch")
+    result = helpers.bulk(elasticsearch_client, variables())
+    print(result)
+
+
 @click.group()
 def command():
     """ddionrails: Elasticsearch index creation/deletion/reset tool."""
@@ -130,3 +261,13 @@ def reset(mapping_file: str) -> None:
     """
     delete()
     create(mapping_file)
+
+
+@command.command("populate", short_help="Populate the Elasticsearch index")
+def populate_command() -> None:
+    """ Populate the Elasticsearch index """
+    populate()
+
+
+# remove "verbosity", "settings", "pythonpath", "traceback", "color" options from django-click
+command.params = command.params[:2] + command.params[7:]

--- a/ddionrails/instruments/imports.py
+++ b/ddionrails/instruments/imports.py
@@ -50,9 +50,6 @@ class InstrumentImport(imports.Import):
             question.label_de = q.get("label_de", q.get("text_de", ""))
             question.items = q.get("items", list)
             question.save()
-            q["namespace"] = self.study.name
-            q["instrument"] = instrument.name
-            question.set_elastic(q)
         instrument.label = content.get("label", "")
         instrument.description = content.get("description", "")
         instrument.save()

--- a/ddionrails/publications/imports.py
+++ b/ddionrails/publications/imports.py
@@ -25,12 +25,7 @@ class PublicationImport(imports.CSVImport):
         return element
 
     def import_element(self, element: OrderedDict) -> Publication:
-        import_object = super().import_element(element)
-        try:
-            import_object.set_elastic(import_object.to_elastic_dict())
-        except:
-            logger.error(f'Failed to import publication "{element["name"]}"')
-        return import_object
+        return super().import_element(element)
 
 
 class AttachmentImport(imports.CSVImport):

--- a/tests/concepts/test_models.py
+++ b/tests/concepts/test_models.py
@@ -5,8 +5,7 @@
 
 import pytest
 
-from ddionrails.concepts.models import Concept, Topic
-from ddionrails.elastic.mixins import ModelMixin
+from ddionrails.concepts.models import Topic
 
 from .factories import TopicFactory
 
@@ -19,27 +18,6 @@ class TestConceptModel:
 
     def test_get_absolute_url_method(self, concept):
         assert concept.get_absolute_url() == "/concept/" + concept.name
-
-    def test_index_method_with_concept_with_label(self, mocker, concept):
-        mocker.patch("ddionrails.elastic.mixins.ModelMixin.set_elastic")
-        concept.index()
-        ModelMixin.set_elastic.assert_called_once()  # pylint: disable=no-member
-
-    def test_index_method_with_concept_without_label(self, mocker, concept_without_label):
-        mocker.patch("ddionrails.elastic.mixins.ModelMixin.set_elastic")
-        concept_without_label.index()
-        ModelMixin.set_elastic.assert_called_once()  # pylint: disable=no-member
-
-    @pytest.mark.django_db
-    def test_index_all_method_with_no_concepts(self):
-        Concept.index_all()
-
-    def test_index_all_method_with_one_concept(
-        self, mocker, concept
-    ):  # pylint: disable=unused-argument
-        mocker.patch("ddionrails.concepts.models.Concept.index")
-        Concept.index_all()
-        Concept.index.assert_called_once()  # pylint: disable=no-member
 
 
 class TestAnalysisUnitModel:

--- a/tests/data/test_imports.py
+++ b/tests/data/test_imports.py
@@ -137,7 +137,6 @@ class TestDatasetJsonImport:
 
     def test_import_variable_method(self, mocker, dataset_json_importer, dataset):
         assert 0 == Variable.objects.count()
-        mocked_set_elastic = mocker.patch.object(Variable, "set_elastic")
         var = dict(
             study="some-study",
             dataset="some-dataset",
@@ -180,13 +179,11 @@ class TestDatasetJsonImport:
         )
         assert "-6" == variable.categories["values"][0]
         assert True is variable.categories["missings"][0]
-        mocked_set_elastic.assert_called_once()
 
     def test_import_variable_method_without_statistics(
         self, mocker, dataset_json_importer, dataset
     ):
         assert 0 == Variable.objects.count()
-        mocked_set_elastic = mocker.patch.object(Variable, "set_elastic")
         var = dict(
             study="some-study",
             dataset="some-dataset",
@@ -199,13 +196,11 @@ class TestDatasetJsonImport:
         assert 1 == Variable.objects.count()
         variable = Variable.objects.first()
         assert dict() == variable.statistics
-        mocked_set_elastic.assert_called_once()
 
     def test_import_variable_method_without_categories(
         self, mocker, dataset_json_importer, dataset
     ):
         assert 0 == Variable.objects.count()
-        mocked_set_elastic = mocker.patch.object(Variable, "set_elastic")
         var = dict(
             study="some-study",
             dataset="some-dataset",
@@ -221,12 +216,10 @@ class TestDatasetJsonImport:
         assert 1 == Variable.objects.count()
         variable = Variable.objects.first()
         assert [] == variable.categories
-        mocked_set_elastic.assert_called_once()
 
     def test_import_variable_method_with_uni_key(
         self, mocker, dataset_json_importer, dataset
     ):
-        mocked_set_elastic = mocker.patch.object(Variable, "set_elastic")
         var = dict(
             study="some-study",
             dataset="some-dataset",
@@ -238,7 +231,6 @@ class TestDatasetJsonImport:
         dataset_json_importer._import_variable(
             var, dataset, sort_id
         )  # pylint: disable=protected-access
-        mocked_set_elastic.assert_called_once()
 
 
 class TestTransformationImport:


### PR DESCRIPTION
## Proposed changes

This PR introduces the following changes:
- add populate to python manage.py index command
- Remove writing into the search engine when importing metadata
- remove index() and index_all() from concepts.Concept
- remove outdated test cases

The index populate command utilizes Elasticsearch's bulk ingest.

Example usage. Import into database and then index into search engine.
```bash
python manage.py update soep-is
python manage.py index populate
```
When experimenting with index settings or if you want to reset your index for some other reason:
```bash
python manage.py index reset
python manage.py index populate
```

Related issue(s): #667

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- Pytest passes locally with my changes
- I have added tests that prove my fix is effective or that my feature works
