### PR TITLE
671: Remove "validate_lowercase" from data.Dataset.name

### DIFF
--- a/ddionrails/data/forms.py
+++ b/ddionrails/data/forms.py
@@ -26,8 +26,7 @@ class DatasetForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.data["boost"] = float(self.data["boost"])
-        self.data["cs_name"] = self.data["dataset_name"]
-        self.data["name"] = self.data["dataset_name"].lower()
+        self.data["name"] = self.data["dataset_name"]
 
 
 class VariableForm(forms.ModelForm):
@@ -47,7 +46,7 @@ class VariableForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.data["name"] = self.data["variable_name"]
         self.data["dataset"] = Dataset.get_or_create(
-            dict(name=self.data["dataset_name"].lower(), study=self.data["study_object"])
+            dict(name=self.data["dataset_name"], study=self.data["study_object"])
         ).pk
         if self.data.get("concept_name", "") == "":
             self.data["concept"] = None

--- a/ddionrails/data/imports.py
+++ b/ddionrails/data/imports.py
@@ -26,7 +26,7 @@ class DatasetJsonImport(imports.Import):
         self._import_dataset(self.name, self.content)
 
     def _import_dataset(self, name, content):
-        import_dict = dict(study=self.study, name=name.lower())
+        import_dict = dict(study=self.study, name=name)
         dataset = Dataset.get_or_create(import_dict)
         sort_id = 0
         if content.__class__ == list:
@@ -84,9 +84,7 @@ class DatasetImport(imports.CSVImport):
             logger.error(f'Failed to import dataset "{element["dataset_name"]}"')
 
     def _import_dataset_links(self, element: OrderedDict):
-        dataset = Dataset.objects.get(
-            study=self.study, name=element["dataset_name"].lower()
-        )
+        dataset = Dataset.objects.get(study=self.study, name=element["dataset_name"])
         period_name = element.get("period_name", "none")
         dataset.period = Period.objects.get_or_create(study=self.study, name=period_name)[
             0
@@ -124,9 +122,7 @@ class VariableImport(imports.CSVImport):
             )
 
     def _import_variable_links(self, element):
-        dataset = Dataset.objects.get(
-            study=self.study, name=element["dataset_name"].lower()
-        )
+        dataset = Dataset.objects.get(study=self.study, name=element["dataset_name"])
         variable = Variable.objects.get(dataset=dataset, name=element["variable_name"])
         concept_name = element.get("concept_name", "").lower()
         if concept_name != "":

--- a/ddionrails/data/migrations/0001_initial.py
+++ b/ddionrails/data/migrations/0001_initial.py
@@ -8,7 +8,6 @@ import filer.fields.image
 from django.conf import settings
 from django.db import migrations, models
 
-import config.validators
 import ddionrails.base.mixins
 import ddionrails.elastic.mixins
 
@@ -30,10 +29,7 @@ class Migration(migrations.Migration):
                 (
                     "name",
                     models.CharField(
-                        db_index=True,
-                        help_text="Name of the dataset (Lowercase)",
-                        max_length=255,
-                        validators=[config.validators.validate_lowercase],
+                        db_index=True, help_text="Name of the dataset", max_length=255
                     ),
                 ),
                 (

--- a/ddionrails/data/models/dataset.py
+++ b/ddionrails/data/models/dataset.py
@@ -6,7 +6,6 @@ import uuid
 from django.db import models
 from django.urls import reverse
 
-from config.validators import validate_lowercase
 from ddionrails.base.mixins import ModelMixin
 from ddionrails.concepts.models import AnalysisUnit, ConceptualDataset, Period
 from ddionrails.studies.models import Study
@@ -31,10 +30,7 @@ class Dataset(ModelMixin, models.Model):
     )
 
     name = models.CharField(
-        max_length=255,
-        validators=[validate_lowercase],
-        db_index=True,
-        help_text="Name of the dataset (Lowercase)",
+        max_length=255, db_index=True, help_text="Name of the dataset"
     )
     label = models.CharField(
         max_length=255,
@@ -108,14 +104,10 @@ class Dataset(ModelMixin, models.Model):
             update_fields=update_fields,
         )
 
-    class Meta:
-        """ Django's metadata options """
-
+    class Meta:  # pylint: disable=missing-docstring,too-few-public-methods
         unique_together = ("study", "name")
 
     class DOR(ModelMixin.DOR):  # pylint: disable=missing-docstring,too-few-public-methods
-        """ ddionrails' metadata options """
-
         id_fields = ["study", "name"]
 
     def __str__(self) -> str:

--- a/tests/data/test_forms.py
+++ b/tests/data/test_forms.py
@@ -30,7 +30,7 @@ class TestDatasetForm:
         form = DatasetForm(data=valid_dataset_data)
         assert form.is_valid() is True
         dataset = form.save()
-        assert dataset.name == "some-dataset"
+        assert dataset.name == "SOME-DATASET"
 
 
 class TestVariableForm:


### PR DESCRIPTION
## Proposed changes

- remove validate_lowercase from data.Dataset.name
- remove lower calls in form
- remove lower calls in import
- remove lower calls in test case

Related issue(s): #671

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- Pytest passes locally with my changes

## Further comments

close #410
