### PR TITLE
701: Make concepts.AnalysisUnit study specific

### DIFF
--- a/ddionrails/concepts/forms.py
+++ b/ddionrails/concepts/forms.py
@@ -55,7 +55,7 @@ class PeriodForm(forms.ModelForm):
 class AnalysisUnitForm(forms.ModelForm):
     class Meta:
         model = AnalysisUnit
-        fields = ("name", "label", "description")
+        fields = ("study", "name", "label", "label_de", "description", "description_de")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ddionrails/concepts/imports.py
+++ b/ddionrails/concepts/imports.py
@@ -72,6 +72,10 @@ class AnalysisUnitImport(imports.CSVImport):
     class DOR:  # pylint: disable=missing-docstring,too-few-public-methods
         form = AnalysisUnitForm
 
+    def process_element(self, element):
+        element["study"] = self.study.id
+        return element
+
 
 class PeriodImport(imports.CSVImport):
     class DOR:  # pylint: disable=missing-docstring,too-few-public-methods

--- a/ddionrails/concepts/models.py
+++ b/ddionrails/concepts/models.py
@@ -308,7 +308,6 @@ class AnalysisUnit(models.Model, ModelMixin):
         db_index=True,
         help_text="UUID of the AnalysisUnit.",
     )
-
     name = models.CharField(
         max_length=255,
         unique=True,
@@ -338,6 +337,19 @@ class AnalysisUnit(models.Model, ModelMixin):
         help_text="Description of the analysis unit (Markdown, German)",
     )
 
+    #############
+    # relations #
+    #############
+    study = models.ForeignKey(
+        Study,
+        related_name="analysis_units",
+        on_delete=models.CASCADE,
+        help_text="Foreign key to studies.Study",
+    )
+
+    class Meta:  # pylint: disable=missing-docstring,too-few-public-methods
+        unique_together = ("study", "name")
+
     def __str__(self) -> str:
         """ Returns a string representation using the "name" field """
         return f"/analysis_unit/{self.name}"
@@ -345,19 +357,8 @@ class AnalysisUnit(models.Model, ModelMixin):
     def save(
         self, force_insert=False, force_update=False, using=None, update_fields=None
     ):
-        """"Set id and call parents save().
-
-        The creation of the value set for the id field is different than
-        for most other models. Analysis units are, like studies, not inside the
-        namespace of any other object, meaning the uuid is derived from
-        the overall base uuid. This could cause a collision of uuids, if
-        a Concept shares a name with a study. While this seems unlikely to
-        happen, it is circumvented by concatenating each name with the
-        literal string `analysis_unit:`.
-        """
-        self.id = uuid.uuid5(  # pylint: disable=C0103
-            settings.BASE_UUID, "analysis_unit:" + self.name
-        )
+        """"Set id and call parents save()."""
+        self.id = uuid.uuid5(self.study_id, self.name)  # pylint: disable=C0103
         super().save(
             force_insert=force_insert,
             force_update=force_update,

--- a/ddionrails/data/imports.py
+++ b/ddionrails/data/imports.py
@@ -82,7 +82,7 @@ class DatasetImport(imports.CSVImport):
         ]
         analysis_unit_name = element.get("analysis_unit_name", "none")
         dataset.analysis_unit = AnalysisUnit.objects.get_or_create(
-            name=analysis_unit_name
+            study=self.study, name=analysis_unit_name
         )[0]
         conceptual_dataset_name = element.get("conceptual_dataset_name", "none")
         dataset.conceptual_dataset = ConceptualDataset.objects.get_or_create(

--- a/tests/concepts/conftest.py
+++ b/tests/concepts/conftest.py
@@ -59,9 +59,10 @@ def minimal_valid_concept_data():
 
 
 @pytest.fixture
-def valid_analysis_unit_data():
-    """ A valid input for analysis unit forms and imports """
+def valid_analysis_unit_data(study):
+    """ A valid input for analysis unit forms and imports, relates to study fixture """
     return dict(
+        study=study.id,
         analysis_unit_name="some-analysis-unit",
         label="Some Analysis unit",
         description="This is some analysis unit",

--- a/tests/concepts/factories.py
+++ b/tests/concepts/factories.py
@@ -26,9 +26,11 @@ class ConceptFactory(factory.django.DjangoModelFactory):
 class AnalysisUnitFactory(factory.django.DjangoModelFactory):
     """Analysis Unit factory"""
 
+    study = factory.SubFactory(StudyFactory, name="some-study")
+
     class Meta:
         model = AnalysisUnit
-        django_get_or_create = ("name",)
+        django_get_or_create = ("study", "name")
 
 
 class ConceptualDatasetFactory(factory.django.DjangoModelFactory):

--- a/tests/concepts/test_forms.py
+++ b/tests/concepts/test_forms.py
@@ -58,7 +58,10 @@ class TestAnalysisUnitForm:
     def test_form_with_invalid_data(self, empty_data):
         form = AnalysisUnitForm(data=empty_data)
         assert form.is_valid() is False
-        expected_errors = {"name": ["This field is required."]}
+        expected_errors = {
+            "name": ["This field is required."],
+            "study": ["This field is required."],
+        }
         assert dict(form.errors) == expected_errors
 
     @pytest.mark.django_db

--- a/tests/concepts/test_imports.py
+++ b/tests/concepts/test_imports.py
@@ -30,9 +30,9 @@ def concept_importer(db, filename):  # pylint: disable=unused-argument
 
 
 @pytest.fixture
-def analysis_unit_importer(db, filename):  # pylint: disable=unused-argument
+def analysis_unit_importer(db, filename, study):  # pylint: disable=unused-argument
     """ An analysis unit importer """
-    return AnalysisUnitImport(filename)
+    return AnalysisUnitImport(filename, study)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,9 @@ def analysis_unit(db):
     return AnalysisUnitFactory(
         name="some-analysis-unit",
         label="Some analysis unit",
+        label_de="Some analysis unit",
         description="This is some analysis unit",
+        description_de="This is some analysis unit",
     )
 
 


### PR DESCRIPTION
## Proposed changes

Related issue(s): #701

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes

## Further comments

- [ ] Please run `makemigrations` and / or `squashmigrations` when merged into `develop`. Django says you cannot add a non nullable field in a later migrations without specifying a default value.
