### PR TITLE
708: Make foreign key to study in Publication required

### DIFF
--- a/ddionrails/publications/migrations/0001_initial.py
+++ b/ddionrails/publications/migrations/0001_initial.py
@@ -186,9 +186,7 @@ class Migration(migrations.Migration):
                 (
                     "study",
                     models.ForeignKey(
-                        blank=True,
                         help_text="Foreign key to studies.Study",
-                        null=True,
                         on_delete=django.db.models.deletion.CASCADE,
                         related_name="publications",
                         to="studies.Study",

--- a/ddionrails/publications/models.py
+++ b/ddionrails/publications/models.py
@@ -62,8 +62,6 @@ class Publication(ElasticMixin, DorMixin, models.Model):
     #############
     study = models.ForeignKey(
         Study,
-        blank=True,
-        null=True,
         related_name="publications",
         on_delete=models.CASCADE,
         help_text="Foreign key to studies.Study",


### PR DESCRIPTION
## Proposed changes

This PR removes `blank=True` and `null=True` from the foreign key field `study` in `publications.Publication`.

Related issue(s): #708

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes
