### PR TITLE
702: Make concepts.ConceptualDataset study specific

### DIFF
--- a/ddionrails/concepts/forms.py
+++ b/ddionrails/concepts/forms.py
@@ -67,7 +67,7 @@ class AnalysisUnitForm(forms.ModelForm):
 class ConceptualDatasetForm(forms.ModelForm):
     class Meta:
         model = ConceptualDataset
-        fields = ("name", "label", "description")
+        fields = ("study", "name", "label", "label_de", "description", "description_de")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ddionrails/concepts/imports.py
+++ b/ddionrails/concepts/imports.py
@@ -85,3 +85,7 @@ class PeriodImport(imports.CSVImport):
 class ConceptualDatasetImport(imports.CSVImport):
     class DOR:  # pylint: disable=missing-docstring,too-few-public-methods
         form = ConceptualDatasetForm
+
+    def process_element(self, element):
+        element["study"] = self.study.id
+        return element

--- a/ddionrails/data/imports.py
+++ b/ddionrails/data/imports.py
@@ -86,7 +86,7 @@ class DatasetImport(imports.CSVImport):
         )[0]
         conceptual_dataset_name = element.get("conceptual_dataset_name", "none")
         dataset.conceptual_dataset = ConceptualDataset.objects.get_or_create(
-            name=conceptual_dataset_name
+            study=self.study, name=conceptual_dataset_name
         )[0]
         dataset.label = element.get("label", "")
         dataset.description = element.get("description", "")

--- a/tests/concepts/conftest.py
+++ b/tests/concepts/conftest.py
@@ -27,7 +27,9 @@ def period_without_label(db):  # pylint: disable=invalid-name,unused-argument
 @pytest.fixture
 def conceptual_dataset_without_label(db):  # pylint: disable=invalid-name,unused-argument
     """ A conceptual_dataset without a label in the database """
-    return ConceptualDatasetFactory(name="some-period", description="This is some period")
+    return ConceptualDatasetFactory(
+        name="some-conceptual-dataset", description="This is some conceptual dataset"
+    )
 
 
 @pytest.fixture
@@ -69,9 +71,10 @@ def valid_analysis_unit_data():
 
 
 @pytest.fixture
-def valid_conceptual_dataset_data():
-    """ A valid input for conceptual dataset forms and imports """
+def valid_conceptual_dataset_data(study):
+    """ A valid input for conceptual dataset forms and imports, relates to study fixture """
     return dict(
+        study=study.id,
         conceptual_dataset_name="some-conceptual-dataset",
         label="Some conceptual dataset",
         description="This is some conceptual dataset",
@@ -82,7 +85,7 @@ def valid_conceptual_dataset_data():
 def valid_period_data(study):
     """ A valid input for period forms and imports, relates to study fixture """
     return dict(
-        study=study.pk,
+        study=study.id,
         period_name="some-period",
         label="Some Period",
         description="This is some period",
@@ -92,4 +95,4 @@ def valid_period_data(study):
 @pytest.fixture
 def valid_topic_data(study):
     """ A valid input for topic forms and imports """
-    return dict(name="some-topic", study=study.pk)
+    return dict(name="some-topic", study=study.id)

--- a/tests/concepts/factories.py
+++ b/tests/concepts/factories.py
@@ -34,9 +34,11 @@ class AnalysisUnitFactory(factory.django.DjangoModelFactory):
 class ConceptualDatasetFactory(factory.django.DjangoModelFactory):
     """Conceptual Dataset factory"""
 
+    study = factory.SubFactory(StudyFactory, name="some-study")
+
     class Meta:
         model = ConceptualDataset
-        django_get_or_create = ("name",)
+        django_get_or_create = ("study", "name")
 
 
 class PeriodFactory(factory.django.DjangoModelFactory):

--- a/tests/concepts/test_forms.py
+++ b/tests/concepts/test_forms.py
@@ -73,7 +73,10 @@ class TestConceptualDatasetForm:
     def test_form_with_invalid_data(self, empty_data):
         form = ConceptualDatasetForm(data=empty_data)
         assert form.is_valid() is False
-        expected_errors = {"name": ["This field is required."]}
+        expected_errors = {
+            "name": ["This field is required."],
+            "study": ["This field is required."],
+        }
         assert dict(form.errors) == expected_errors
 
     @pytest.mark.django_db

--- a/tests/concepts/test_imports.py
+++ b/tests/concepts/test_imports.py
@@ -36,9 +36,9 @@ def analysis_unit_importer(db, filename):  # pylint: disable=unused-argument
 
 
 @pytest.fixture
-def conceptual_dataset_importer(db, filename):  # pylint: disable=unused-argument
+def conceptual_dataset_importer(db, filename, study):  # pylint: disable=unused-argument
     """ A conceptual dataset importer """
-    return ConceptualDatasetImport(filename)
+    return ConceptualDatasetImport(filename, study)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,12 +61,15 @@ def concept_question(db):  # pylint: disable=unused-argument,invalid-name
 
 
 @pytest.fixture
-def conceptual_dataset(db):
-    """ A conceptual dataset in the database """
+def conceptual_dataset(study):
+    """ A conceptual dataset in the database, relates to study fixture """
     return ConceptualDatasetFactory(
         name="some-conceptual-dataset",
         label="Some conceptual dataset",
+        label_de="Some conceptual dataset",
         description="This is some conceptualdataset",
+        description_de="This is some conceptualdataset",
+        study=study,
     )
 
 


### PR DESCRIPTION
## Proposed changes

Related issue(s): #702

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes

## Further comments

- [ ] Please run `makemigrations` and / or `squashmigrations` when merged into `develop`. Django says you cannot add a non nullable field in a later migrations without specifying a default value.
