### PR TITLE
Refactor/update docker setup

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 services:
   web:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
   web:
-    command: python /usr/src/app/manage.py runserver_plus --print-sql 0.0.0.0:8000
+    command: bash -c "while [ 1 ]; do python /usr/src/app/manage.py runserver_plus --print-sql 0.0.0.0:8000; test $$? -gt 128 && break; done"
     env_file: 
       - docker/environments/django.env.example
       - docker/environments/database.env.example

--- a/docker-compose-remote-dev.yml
+++ b/docker-compose-remote-dev.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 services:
   web:

--- a/docker-compose-remote-dev.yml
+++ b/docker-compose-remote-dev.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./
       dockerfile: ./docker/ddionrails/dev.Dockerfile
-    command: python /usr/src/app/manage.py runserver_plus --print-sql 0.0.0.0:8000
+    command: bash -c "while [ 1 ]; do python /usr/src/app/manage.py runserver_plus --print-sql 0.0.0.0:8000; test $$? -gt 128 && break; done"
     entrypoint: ./docker/ddionrails/entrypoint.sh
     env_file: 
       - docker/environments/django.env.example

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 services:
   web:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 services:
   web:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,12 @@ services:
         ipv6_address: 2001:3984:3989::10
     ports: 
       - 8000
+    restart: on-failure:5
+    security_opt: 
+      - no-new-privileges
     volumes: 
       - static:/usr/src/app/static
       - media:/var/django/media
-    restart: unless-stopped
 
   postgres:
     image: postgres:11.4-alpine 
@@ -47,6 +49,9 @@ services:
       retries: 5
     networks:
       - ddi_net
+    security_opt: 
+      - no-new-privileges
+    restart: on-failure:5
     volumes:
       # Config
       - ddi-psql-config:/etc/postgresql
@@ -67,6 +72,9 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     networks:
       - ddi_net
+    restart: on-failure:5
+    security_opt: 
+      - no-new-privileges
     ulimits:
       memlock:
         soft: -1
@@ -79,6 +87,9 @@ services:
       context: ./docker/postfix/
     networks:
       - ddi_net
+    restart: on-failure:5
+    security_opt: 
+      - no-new-privileges
 
   nginx:
     image: nginx:1.17-alpine
@@ -90,6 +101,9 @@ services:
       - HOST_NAME=127.0.0.1
     networks:
       - ddi_net
+    restart: on-failure:5
+    security_opt: 
+      - no-new-privileges
     volumes: 
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf
       - static:/usr/src/app/static:ro
@@ -99,6 +113,9 @@ services:
     image: redis:4-alpine3.9
     networks:
       - ddi_net
+    restart: on-failure:5
+    security_opt: 
+      - no-new-privileges
 
 volumes:
   elastic_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
             "--access-logformat",
             "[gunicorn] %(h)s %(l)s %(u)s %(t)s %(r)s %(s)s %(b)s %(f)s %(a)s",
              ] 
+    depends_on:
+      postgres:
+        condition: service_healthy
     # Set your own variables, use of the example files at your own risk.
     #env_file:
     #  - docker/environments/django.env
@@ -37,6 +40,11 @@ services:
     # Set your own variables, use of the example files at yout own risk.
     #env_file:
     #  - docker/environments/database.env
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - ddi_net
     volumes:

--- a/docker/ddionrails/dev.Dockerfile
+++ b/docker/ddionrails/dev.Dockerfile
@@ -13,12 +13,12 @@ COPY ./ ${DOCKER_APP_DIRECTORY}/
 RUN  apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential=12.3 \
+        curl=7.52.1-5+deb9u9 \
         git=1:2.11.0-3+deb9u4 \
         graphviz=2.38.0-17 \
         graphviz-dev=2.38.0-17 \
-        curl=7.52.1-5+deb9u9 \
-        python-psycopg2=2.6.2-1 \
         netcat=1.10-41 \
+        python-psycopg2=2.6.2-1 \
     && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get install -y --no-install-recommends nodejs=12.6.0-1nodesource1 \
     && rm -rf /var/lib/apt/lists/* 

--- a/docker/ddionrails/dev.Dockerfile
+++ b/docker/ddionrails/dev.Dockerfile
@@ -12,6 +12,7 @@ COPY ./ ${DOCKER_APP_DIRECTORY}/
 
 RUN  apt-get update \
     && apt-get install -y --no-install-recommends \
+        bash-completion=1:2.1-4.3 \
         build-essential=12.3 \
         curl=7.52.1-5+deb9u9 \
         git=1:2.11.0-3+deb9u4 \

--- a/docker/ddionrails/entrypoint.sh
+++ b/docker/ddionrails/entrypoint.sh
@@ -12,7 +12,7 @@ if [ "${DEPENDENCY_DIFF}" -gt 0 ] || [ ! -f "${LIVE_DEPENDENCIES}" ]; then
     echo "Image dependencies have changed."
     echo "Overwriting old dependencies."
     rm -rf /usr/src/app/static/dist/*
-    ./node_modules/.bin/webpack --config webpack.config.js
+    npm run build
     cp ${BUILD_DEPENDENCIES} ${LIVE_DEPENDENCIES}
 fi
 

--- a/docker/ddionrails/entrypoint.sh
+++ b/docker/ddionrails/entrypoint.sh
@@ -16,25 +16,6 @@ if [ "${DEPENDENCY_DIFF}" -gt 0 ] || [ ! -f "${LIVE_DEPENDENCIES}" ]; then
     cp ${BUILD_DEPENDENCIES} ${LIVE_DEPENDENCIES}
 fi
 
-# The Database container may not be there yet
-echo "Waiting for Database"
-
-if [ -z "${POSTGRES_HOST}" ]; then
-    echo "Error: POSTGRES_HOST is not set"
-    exit 0
-fi
-
-if [ -z "${POSTGRES_PORT}" ]; then
-    echo "Error: POSTGRES_PORT is not set"
-    exit 0
-fi
-
-while ! nc -z "${POSTGRES_HOST}" "${POSTGRES_PORT}"; do
-    sleep 0.1
-done
-
-echo "Database started"
-
 
 # Collect Admin stiling etc.
 python manage.py collectstatic --noinput


### PR DESCRIPTION
There were several shortcomings with the docker setup, that where addressed in the commits to be merged.


# [docker] Downgrade to compose Version 2.4

- Compose version 3.0 moved important features
  into a section that only applies to swarm nodes.

- Compose developers see a divide between version 2 and 3
  and want version 3 to be only used with swarm setups.

- Version 2 will be supported into the future for users
  that do not use swarm.

# [docker] Replace old service dependency management

- Postgres Healthcheck was moved from webs enrypoint to compose file.
- Healthcheck uses pg_isready to determine the status.
- Web depends on the healthcheck in the compose file.
  - Starts up, only after health check is passed.

# [docker-dev] Keep web alive for development

- Changes in the django code can cause the django server to crash.
- The server takes the container with it, if it crashes.

  - The development environment should not kick the developer out
    if they make changes that crashes the server.

- Django server is now restarted in a loop unless killed explicitly.

# [docker] Update security setup

- Add security_opt to keep services from getting more privileges.
- Change restart policy to avoid endless retries.


# [refactor]
- Sort dev.Dockerfile installs  simplify function call in entrypoint

# [docker-dev] Add bash-completion to dev-container 