### PR TITLE
Modify settings in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --cov --cov-report html --cov-branch --no-migrations --reuse-db -v -m "not functional"
+addopts = --cov --cov-report html --cov-branch --no-migrations --reuse-db -rf -m "not functional"
 DJANGO_SETTINGS_MODULE = config.settings.testing
 python_files = test_*.py
 testpaths = tests
@@ -53,7 +53,7 @@ output-format = colorized
 load-plugins=pylint_django
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 check_untyped_defs = True
 ignore_errors = False
 ignore_missing_imports = True


### PR DESCRIPTION
##  Proposed changes

This PR introduces the following changes:
- replace "-v" with "-rf" in pytest settings to disable verbose mode
  and display the failed tests in a summary section
- bump python_version to 3.7 in mypy section

Related issue(s): None

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes
