### PR TITLE
[close #727] Move elastic proxy into nginx.conf

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -11,7 +11,7 @@ from django.views.generic.base import TemplateView
 
 import ddionrails.instruments.views as instruments_views
 import ddionrails.publications.views as publications_views
-from config.views import HomePageView, elastic_proxy
+from config.views import HomePageView
 from ddionrails.data.views import DatasetRedirectView, VariableRedirectView
 from ddionrails.elastic.views import angular as angular_search
 from ddionrails.studies.views import StudyDetailView, StudyRedirectView, study_topics
@@ -47,7 +47,6 @@ urlpatterns = [
     path("django-rq/", include("django_rq.urls")),
     path("user/", include("django.contrib.auth.urls")),
     path("accounts/login/", LoginView.as_view()),
-    path("elastic<path:path>", elastic_proxy),
     # Study by name
     path("<slug:study_name>", StudyDetailView.as_view(), name="study_detail"),
     # Study-specific links

--- a/config/views.py
+++ b/config/views.py
@@ -2,10 +2,7 @@
 
 """ Views for ddionrails project """
 
-from django.core.handlers.wsgi import WSGIRequest
-from django.http import HttpResponse
 from django.shortcuts import render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import TemplateView
 from urllib3 import PoolManager
 
@@ -45,7 +42,7 @@ def server_error(request):
 
 
 class HomePageView(TemplateView):
-    """ The HomepageView of the ddionrails project renders a list of all available studies. """
+    """ Renders a list of all available studies. """
 
     template_name = "pages/home.html"
 
@@ -53,12 +50,3 @@ class HomePageView(TemplateView):
         context = super().get_context_data(**kwargs)
         context["study_list"] = Study.objects.all()
         return context
-
-
-@csrf_exempt
-def elastic_proxy(request: WSGIRequest, path: str) -> HttpResponse:
-    """ Custom elasticsearch proxy """
-    response = HTTP.request(
-        "GET", "http://elasticsearch:9200/%s" % path, body=request.body
-    )
-    return HttpResponse(response.data)

--- a/docker-compose-remote-dev.yml
+++ b/docker-compose-remote-dev.yml
@@ -29,10 +29,6 @@ services:
     env_file:
       - docker/environments/database.env.example
 
-  elasticsearch:
-    ports:
-      - 9200:9200
-
 # Uncomment these lines, if you want to use Kibana
 #  kibana:
 #    image: kibana:4.6.0

--- a/docker/nginx/nginx.dev.conf
+++ b/docker/nginx/nginx.dev.conf
@@ -57,6 +57,28 @@ http {
       try_files $uri @proxy_to_app;
     }
 
+    location /static/ {
+            autoindex off;
+            root /usr/src/app;
+    }
+
+    location /media/ {
+            autoindex off;
+            root /var/django;
+    }
+
+    location /elastic/ {
+            autoindex off;
+            proxy_pass http://elasticsearch:9200/;
+            proxy_set_header X-Forwarded-For
+              $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            limit_except GET POST {
+              deny  all;
+            }
+    }
+
     location @proxy_to_app {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;

--- a/docker/nginx/nginx.example.conf
+++ b/docker/nginx/nginx.example.conf
@@ -77,13 +77,25 @@ http {
 
 
     location /static/ {
-            autoindex on;
+            autoindex off;
             root /usr/src/app;
     }
 
     location /media/ {
-            autoindex on;
+            autoindex off;
             root /var/django;
+    }
+
+    location /elastic/ {
+            autoindex off;
+            proxy_pass http://elasticsearch:9200/;
+            proxy_set_header X-Forwarded-For
+              $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            limit_except GET POST {
+              deny  all;
+            }
     }
 
     location / {

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,9 +42,12 @@ known_third_party=PIL,click,dateutil,django,django_rq,djclick,elasticsearch,elas
 known_first_party=ddionrails,tests
 
 [pylint]
-# Run with: "pylint --rcfile=setup.cfg config ddionrails" or "PYLINTRC=setup.cfg pylint config ddionrails"
+# Run with: "pylint --rcfile=setup.cfg config ddionrails" or
+# "PYLINTRC=setup.cfg pylint config ddionrails"
 max-line-length=90
-disable = C0330,R0801
+# Remove C0412 for the next pylint release
+# which works with isorts grouping 
+disable = C0330,R0801,C0412
 ignore = migrations
 output-format = colorized
 


### PR DESCRIPTION
- Remove the proxy setup for the elasticsearch container from django
- Add location configs to nginx.dev.conf and nginx.example.conf
- Remove host port binding of elasticsearch from -remote-dev.yml

- Update pylint config to work better with isort