### PR TITLE
Remove "ignoreDeps: bootstrap" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
     "extends": [
       "config:base"
     ],
-    "ignoreDeps": [
-      "bootstrap"
-    ],
     "lockFileMaintenance": {
       "enabled": true
     },


### PR DESCRIPTION
## Proposed changes

ignoreDeps can be removed from package.json, as the update to Bootstrap 4 is now completed.

Related issue(s): None

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

N.A.
