### PR TITLE
Remove unique constraint from "name" field in AnalysisUnit ...

### DIFF
--- a/ddionrails/concepts/admin.py
+++ b/ddionrails/concepts/admin.py
@@ -9,12 +9,17 @@ from .models import AnalysisUnit, Concept, ConceptualDataset, Period, Topic
 
 
 @admin.register(AnalysisUnit)
-class AnalysisUnitAdmin(admin.ModelAdmin):
+class AnalysisUnitAdmin(AdminMixin, admin.ModelAdmin):
     """ ModelAdmin for concepts.AnalysisUnit """
 
-    list_display = ("name", "label", "label_de")
+    list_display = ("name", "label", "label_de", "study_name")
+    list_filter = ("study__name",)
     list_per_page = 25
+    list_select_related = ("study",)
     search_fields = ("name", "label", "label_de")
+
+    AdminMixin.study_name.admin_order_field = "study"
+    AdminMixin.study_name.short_description = "study"
 
 
 @admin.register(Concept)
@@ -28,12 +33,17 @@ class ConceptAdmin(admin.ModelAdmin):
 
 
 @admin.register(ConceptualDataset)
-class ConceptualDatasetAdmin(admin.ModelAdmin):
+class ConceptualDatasetAdmin(AdminMixin, admin.ModelAdmin):
     """ ModelAdmin for concepts.ConceptualDataset """
 
-    list_display = ("name", "label", "label_de")
+    list_display = ("name", "label", "label_de", "study_name")
+    list_filter = ("study__name",)
     list_per_page = 25
+    list_select_related = ("study",)
     search_fields = ("name", "label", "label_de")
+
+    AdminMixin.study_name.admin_order_field = "study"
+    AdminMixin.study_name.short_description = "study"
 
 
 @admin.register(Period)

--- a/ddionrails/concepts/migrations/0001_initial.py
+++ b/ddionrails/concepts/migrations/0001_initial.py
@@ -262,7 +262,6 @@ class Migration(migrations.Migration):
                     models.CharField(
                         help_text="Name of the conceptual dataset (Lowercase)",
                         max_length=255,
-                        unique=True,
                         validators=[config.validators.validate_lowercase],
                     ),
                 ),
@@ -335,7 +334,6 @@ class Migration(migrations.Migration):
                     models.CharField(
                         help_text="Name of the analysis unit (Lowercase)",
                         max_length=255,
-                        unique=True,
                         validators=[config.validators.validate_lowercase],
                     ),
                 ),

--- a/ddionrails/concepts/models.py
+++ b/ddionrails/concepts/models.py
@@ -314,7 +314,6 @@ class AnalysisUnit(models.Model, ModelMixin):
     )
     name = models.CharField(
         max_length=255,
-        unique=True,
         validators=[validate_lowercase],
         help_text="Name of the analysis unit (Lowercase)",
     )
@@ -354,6 +353,9 @@ class AnalysisUnit(models.Model, ModelMixin):
     class Meta:  # pylint: disable=missing-docstring,too-few-public-methods
         unique_together = ("study", "name")
 
+    class DOR:  # pylint: disable=missing-docstring,too-few-public-methods
+        id_fields = ("study", "name")
+
     def __str__(self) -> str:
         """ Returns a string representation using the "name" field """
         return f"/analysis_unit/{self.name}"
@@ -392,7 +394,6 @@ class ConceptualDataset(models.Model, ModelMixin):
     )
     name = models.CharField(
         max_length=255,
-        unique=True,
         validators=[validate_lowercase],
         help_text="Name of the conceptual dataset (Lowercase)",
     )
@@ -431,6 +432,9 @@ class ConceptualDataset(models.Model, ModelMixin):
 
     class Meta:  # pylint: disable=missing-docstring,too-few-public-methods
         unique_together = ("study", "name")
+
+    class DOR:  # pylint: disable=missing-docstring,too-few-public-methods
+        id_fields = ("study", "name")
 
     def __str__(self) -> str:
         """ Returns a string representation using the "name" field """


### PR DESCRIPTION
 and ConceptualDataset

## Proposed changes

Before merging #710 and #717 I forgot to remove the unique constraint from the "name" fields in concepts.AnalysisUnit and concepts.ConceptualDataset. This will result in not being able to import two analyis units from different studies with the same name, e.g. "p".

Also the importers did not work as expected, because "DOR.id_fields" is necessary.

Related issue(s): None

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes
