### PR TITLE
[WIP] -FIX- Filter categories for elasticsearch

### DIFF
--- a/ddionrails/data/migrations/0001_initial.py
+++ b/ddionrails/data/migrations/0001_initial.py
@@ -234,7 +234,7 @@ class Migration(migrations.Migration):
                     "categories",
                     django.contrib.postgres.fields.jsonb.JSONField(
                         blank=True,
-                        default=list,
+                        default=dict,
                         help_text="Categories of the variable(JSON)",
                         null=True,
                     ),

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -91,7 +91,7 @@ class Variable(ElasticMixin, DorMixin, models.Model):
         max_length=255, null=True, blank=True, help_text="Scale of the variable"
     )
     categories = JSONBField(
-        default=list, null=True, blank=True, help_text="Categories of the variable(JSON)"
+        default=dict, null=True, blank=True, help_text="Categories of the variable(JSON)"
     )
 
     #############

--- a/ddionrails/elastic/mapping.json
+++ b/ddionrails/elastic/mapping.json
@@ -66,6 +66,16 @@
             }
           }
         },
+        "categories": {
+          "properties": {
+            "labels": {
+              "type": "string"
+            },
+            "labels_de": {
+              "type": "string"
+            }
+          }
+        },
         "study": {
           "type": "string",
           "fields": {


### PR DESCRIPTION
Problem
-------

- Somewhat numeric data was send to the elastic index
- Numeric data had some data points, that could not be cast to a number
- Numeric data was superfluous in the index

Solution
--------

Numeric fields are now filtered out before sending data to elastic.