### PR TITLE
Switch to vanilla alpine

### DIFF
--- a/docker/postfix/Dockerfile
+++ b/docker/postfix/Dockerfile
@@ -1,8 +1,6 @@
-FROM python:3.7.3-alpine
+FROM alpine:3.10.1
 
-RUN apk update \
-    && apk add postfix \
-    && rm -rf /var/cache/apk/*
+RUN apk add --no-cache postfix=3.4.5-r0
 
 RUN echo "mynetworks = 172.16.238.10" >> /etc/postfix/main.cf
 


### PR DESCRIPTION
## Proposed changes

Switch to vanilla alpine

- Python is not needed inside the container.

  - Use of Python image was probably a copy paste error

- Also cleaned up Dockerfile to conform with hadolint