### PR TITLE
Fix formatting mess in publication_detail template

### DIFF
--- a/templates/publications/publication_detail.html
+++ b/templates/publications/publication_detail.html
@@ -4,8 +4,8 @@
         <div class="card-body">
             <div class="text-center">
                 <p class="lead">
-                    {{ publication.author }}(
-                    {{ publication.year }})</p>
+                    {{ publication.author }} ({{ publication.year }})
+                </p>
                 <h1>{{ publication.title }}</h1>
                 {% if publication.sub_type %}
                     <p>[


### PR DESCRIPTION
## Proposed changes

The auto-formatting messed up the Author (Year) formatting.
It was Author( Year) after auto-formatting.

Related issue(s): None

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- Pytest passes locally with my changes
