### PR TITLE
-FIX- Keep static/dist from being empty

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,12 @@ services:
     security_opt: 
       - no-new-privileges
     volumes: 
-      - static:/usr/src/app/static
+      - type: volume
+        source: static
+        target: /usr/src/app/static
+        volume:
+          nocopy: false
+
       - media:/var/django/media
 
   postgres:
@@ -117,7 +122,12 @@ services:
       - no-new-privileges
     volumes: 
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - static:/usr/src/app/static:ro
+      - type: volume
+        source: static
+        target: /usr/src/app/static
+        read_only: true
+        volume:
+          nocopy: true
       - media:/var/django/media
 
   redis:

--- a/docker/ddionrails/dev/dev.Dockerfile
+++ b/docker/ddionrails/dev/dev.Dockerfile
@@ -40,7 +40,7 @@ RUN pipenv install --dev
 WORKDIR ${DOCKER_APP_DIRECTORY}
 
 # Set up entrypoint
-COPY ./docker/ddionrails/entrypoint.sh ${DOCKER_APP_DIRECTORY}/
+COPY ./docker/ddionrails/dev/entrypoint.sh ${DOCKER_APP_DIRECTORY}/
 
 # Some dev creature comforts for bash work
 COPY ./docker/ddionrails/dev/dev.bashrc /root/.bashrc

--- a/docker/ddionrails/dev/entrypoint.sh
+++ b/docker/ddionrails/dev/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Update static files if needed.
+WEBPACK_STATS=webpack-stats.json
+BUILD_DEPENDENCIES=/usr/src/app/${WEBPACK_STATS}
+LIVE_DEPENDENCIES=/usr/src/app/static/${WEBPACK_STATS}
+
+echo "Check for old dependencies"
+cmp "${BUILD_DEPENDENCIES}" "${LIVE_DEPENDENCIES}"
+DEPENDENCY_DIFF=$?
+
+if [ "${DEPENDENCY_DIFF}" -gt 0 ] || [ ! -f "${LIVE_DEPENDENCIES}" ] || [ ! -f "${BUILD_DEPENDENCIES}" ]; then
+    echo "Image dependencies have changed."
+    echo "Overwriting old dependencies."
+    rm -rf /usr/src/app/static/dist/*
+    npm install
+    cd /usr/src/app
+    npm run build
+    cp ${BUILD_DEPENDENCIES} ${LIVE_DEPENDENCIES}
+fi
+
+
+# Collect Admin stiling etc.
+python manage.py collectstatic --noinput
+
+echo "Initialising System"
+python manage.py system || echo "Initialising System failed." &
+
+echo "Running migrations."
+python manage.py migrate && \
+echo "Starting rqworker" && \
+python manage.py rqworker &
+
+echo "Creating search indices"
+python manage.py search_index --create || echo "Creating search indices failed." &
+
+echo "Starting server"
+exec "$@"
+

--- a/docker/ddionrails/entrypoint.sh
+++ b/docker/ddionrails/entrypoint.sh
@@ -1,24 +1,4 @@
 #!/bin/bash
-# Update static files if needed.
-WEBPACK_STATS=webpack-stats.json
-BUILD_DEPENDENCIES=/usr/src/app/${WEBPACK_STATS}
-LIVE_DEPENDENCIES=/usr/src/app/static/${WEBPACK_STATS}
-
-echo "Check for old dependencies"
-cmp "${BUILD_DEPENDENCIES}" "${LIVE_DEPENDENCIES}"
-DEPENDENCY_DIFF=$?
-
-if [ "${DEPENDENCY_DIFF}" -gt 0 ] || [ ! -f "${LIVE_DEPENDENCIES}" ] || [ ! -f "${BUILD_DEPENDENCIES}" ]; then
-    echo "Image dependencies have changed."
-    echo "Overwriting old dependencies."
-    rm -rf /usr/src/app/static/dist/*
-    npm install
-    cd /usr/src/app
-    npm run build
-    cp ${BUILD_DEPENDENCIES} ${LIVE_DEPENDENCIES}
-fi
-
-
 # Collect Admin stiling etc.
 python manage.py collectstatic --noinput
 


### PR DESCRIPTION
Problem
-------

* Production image no longer contains npm, as it is removed after
the webpack build process.
* entrypoint.sh contains a section to update npm packages.

  + This rebuild removed all files build by webpack before rebuilding.
  + Rebuilding could not be done since npm was no longer installed.
  + This left static/dist empty.

Patch
-----

* entrypoints for development and production are now separate.

  + The content of static/dist is now neither rebuild nor removed inside
    the production container.

* Mounting of the static volume is now more verbose/explicit.

  + web now mounts it explicitly with nocopy set to false
  + nginx now mounts it explicitly with nocopy set to true

NOTE
----

Changes of npm dependencies should only come through newly build images
to production systems.