### PR TITLE
-FIX- Minor adjustments for Bootstrap 4

### DIFF
--- a/templates/data/variable_detail.html
+++ b/templates/data/variable_detail.html
@@ -30,34 +30,40 @@
             <div>
                 <!-- Nav tabs -->
                 <ul class="nav nav-tabs" role="tablist">
-                    <li role="presentation" class="active nav-item"><a href="#related_variables"
-                                                                       aria-controls="related_variables" role="tab"
-                                                                       data-toggle="tab" class="nav-link">
-
-                        Related variables
-
-                        <span class="badge">{{ variable.get_related_variables | length }}</span>
-
+                    <li role="presentation" class="nav-item">
+                        <a href="#related_variables"
+                        aria-controls="related_variables"
+                            data-toggle="tab"
+                            class="nav-link active"
+                        >
+                            Related variables
+                            <span class="badge badge-secondary">
+                                {{ variable.get_related_variables | length }}
+                            </span>
+                        </a>
+                    </li>
+                    <li role="presentation" class="nav-item">
+                        <a href="#origin_variables"
+                           aria-controls="origin_variables"
+                           data-toggle="tab"
+                           class="nav-link"
+                        >
+                            Input variables
+                            <span class="badge badge-secondary">
+                                {{ variable.origin_variables.count }}
+                            </span>
                     </a>
                     </li>
-                    <li role="presentation" class="nav-item"><a href="#origin_variables"
-                                                                aria-controls="origin_variables" role="tab"
-                                                                data-toggle="tab" class="nav-link">
-
-                        Input variables
-
-                        <span class="badge">{{ variable.origin_variables.count }}</span>
-
-                    </a>
-                    </li>
-                    <li role="presentation" class="nav-item"><a href="#target_variables"
-                                                                aria-controls="target_variables" role="tab"
-                                                                data-toggle="tab" class="nav-link">
-
-                        Output variables
-
-                        <span class="badge">{{ variable.target_variables.count }}</span>
-
+                    <li role="presentation" class="nav-item">
+                        <a href="#target_variables"
+                           aria-controls="target_variables"
+                           data-toggle="tab"
+                           class="nav-link"
+                        >
+                            Output variables
+                            <span class="badge badge-secondary">
+                                {{ variable.target_variables.count }}
+                            </span>
                     </a>
                     </li>
                 </ul>


### PR DESCRIPTION
* Moved active class, that works in conjunction with nav-tabs,
  from nav-item to nav-link. First tab is now styled correctly
  when first loading the page.
* added class `badge-secondary` to nodes classed with `badge`.
  Badges are now styled correctly.