### PR TITLE
-FIX- mobile menu now collapses correctly

### DIFF
--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -26,11 +26,9 @@ body {
 }
 
 #paneldata-navbar {
-  @extend .navbar;
   @extend .fixed-top;
   @extend .navbar-light;
-  @extend .flex-column;
-  @extend .navbar-expand-md;
+  flex-direction: column;
   padding: 1em 1.5em 1em 2em !important;
   border-bottom: 1px solid black !important;
   background-color: #f8f9fa !important;

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,7 @@
     <body>
     {% block header %}
     {% endblock header %}
-    <nav id="paneldata-navbar" id="nav-container">
+    <nav id="paneldata-navbar" id="nav-container" class="navbar-expand-md">
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Problem
-------

* navbar class forced `display: flex` on the navbar.
* `display: flex` suppressed `display: none` needed for collapsing.

Solution
--------

index.scss was modified to remove `display: flex !important`
from id paneldata-navbar.