### PR TITLE
-FIX- Stop facet checkbox from shrinking

### DIFF
--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -192,3 +192,8 @@ div.dataTables_paginate li.last a:after {
   background-color: rgb(151, 150, 150);
   border-color: rgb(184, 181, 181);
 }
+
+/* Stops facet checkbox from shrinking when facet text is long.*/
+.css-1x5fnvc + label::before {
+  min-width: 15px;
+}


### PR DESCRIPTION
Problem
-------

Long facet names caused checkbox to shrink to `1px`.

Solution
--------

Set `min-width` equal to `width`, i.e. `15px`.