### PR TITLE
[patch] Switch from pipenv install to pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 env:
   global:
-  - COMPOSE_FILE=docker-compose.yml:docker-compose-travis.yml
+    - COMPOSE_FILE=docker-compose.yml:docker-compose-travis.yml
 before_install:
   - docker --version
   - docker-compose --version
@@ -14,11 +14,8 @@ before_script:
   - docker-compose up --build -d
   - docker images
   - docker ps -a
-  - >-
-    docker-compose exec web
-    bash -c '
-    bash -c "pipenv lock -r  && pipenv lock -r -d" |
-    sort | uniq > Requirements.txt'
+  - docker-compose exec web pip install pipfile-requirements==0.1.0.post0
+  - docker-compose exec web bash -c "pipfile2req -d Pipfile.lock > Requirements.txt"
   - docker-compose exec web pip install -r Requirements.txt
   - docker-compose exec web npm install
   - docker-compose exec web npm run build

--- a/docker/ddionrails/Dockerfile
+++ b/docker/ddionrails/Dockerfile
@@ -20,12 +20,14 @@ RUN apk add --no-cache \
         nodejs-npm \
         postgresql-dev \
         zlib-dev \
-    && pip install --upgrade pipenv \
-    && pipenv install --system --ignore-pipfile \
+    && pip install --no-cache-dir --upgrade pipfile-requirements==0.1.0.post0 \
+    && pipfile2req Pipfile.lock > Requirements.txt \
+    && pip install --no-cache-dir -r Requirements.txt \
+    && pip uninstall -y pipfile-requirements \
+    && rm Requirements.txt \
     && npm install \
     && npm run build \
     && apk del nodejs nodejs-npm \
-    && pip uninstall -y pipenv \
     && rm -rf /var/cache/apk/* \
     && rm -rf node_modules 
 

--- a/docker/ddionrails/dev/dev.Dockerfile
+++ b/docker/ddionrails/dev/dev.Dockerfile
@@ -24,6 +24,10 @@ RUN apt-get update \
         openssh-client=1:7.4p1-10+deb9u6 \
         python-psycopg2=2.6.2-1 \
         vim-tiny=2:8.0.0197-4+deb9u3 \
+    && pip install --no-cache-dir --upgrade pipfile-requirements==0.1.0.post0 \
+    && pipfile2req --dev Pipfile.lock > Requirements.txt \
+    && pip install --no-cache-dir -r Requirements.txt \
+    && rm Requirements.txt \
     && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get install -y --no-install-recommends nodejs=12.* \
     && npm install \
@@ -34,7 +38,6 @@ RUN apt-get update \
 # hadolint ignore=DL3013
 RUN pip install --upgrade pipenv
 # It turned out to be easier to work with the dev dependencies in a venv
-RUN pipenv install --dev --system
 
 WORKDIR ${DOCKER_APP_DIRECTORY}
 


### PR DESCRIPTION
* Pipenv creates a venv for installation and creation of a
  Requirements.txt
* The venv is not needed and it's creation takes too much time
* The `pipfile-requirements` package can convert a Pipfile.lock
  to a Requirements.txt

  * This is much faster than working with pipenv for system installation

* Pipenv install was replaced in all Dockerfiles and the travis setup
