### PR TITLE
[Close #815] Add function to alter result text

### DIFF
--- a/assets/js/search/components/searches/BaseSearch.vue
+++ b/assets/js/search/components/searches/BaseSearch.vue
@@ -29,6 +29,7 @@
           :from="0"
           :size="10"
           :showResultStats="true"
+          :renderResultStats="customRenderStats"
           class="result-list-container"
           :react="{ and: ['Search', 'Study'] }"
           renderNoResults="No Concepts found. Try to change your search query or filter options."
@@ -106,6 +107,11 @@ export default {
     PublicationResult,
     TopicResult,
     VariableResult
+  },
+  methods: {
+    customRenderStats(stats) {
+      return helpers.customRenderStats(this, stats);
+    }
   }
 };
 </script>

--- a/assets/js/search/components/searches/ConceptSearch.vue
+++ b/assets/js/search/components/searches/ConceptSearch.vue
@@ -30,6 +30,7 @@
           :from="0"
           :size="10"
           :showResultStats="true"
+          :renderResultStats="customRenderStats"
           :react="{ and: ['Search', 'Study'] }"
           renderNoResults="No Concepts found. Try to change your search query or filter options."
           class="result-list-container m-0 p-0 col-12"
@@ -59,6 +60,11 @@ export default {
   components: {
     StudyFacet,
     ConceptResult
+  },
+  methods: {
+    customRenderStats(stats) {
+      return helpers.customRenderStats(this, stats);
+    }
   }
 };
 </script>

--- a/assets/js/search/components/searches/PublicationSearch.vue
+++ b/assets/js/search/components/searches/PublicationSearch.vue
@@ -32,6 +32,7 @@
           :from="0"
           :size="10"
           :showResultStats="true"
+          :renderResultStats="customRenderStats"
           class="result-list-container"
           :react="{ and: ['Search', 'Study', 'Type', 'Year'] }"
           renderNoResults="No Publications found. Try to change your search query or filter options."
@@ -70,6 +71,11 @@ export default {
     PublicationTypeFacet,
     PublicationYearFacet,
     PublicationResult
+  },
+  methods: {
+    customRenderStats(stats) {
+      return helpers.customRenderStats(this, stats);
+    }
   }
 };
 </script>

--- a/assets/js/search/components/searches/QuestionSearch.vue
+++ b/assets/js/search/components/searches/QuestionSearch.vue
@@ -32,6 +32,7 @@
           :from="0"
           :size="10"
           :showResultStats="true"
+          :renderResultStats="customRenderStats"
           class="result-list-container"
           :react="{ and: ['AnalysisUnit', 'Period', 'Search', 'Study'] }"
           renderNoResults="No Results found. Try to change your search query or filter options."
@@ -78,6 +79,11 @@ export default {
     PeriodFacet,
     StudyFacet,
     QuestionResult
+  },
+  methods: {
+    customRenderStats(stats) {
+      return helpers.customRenderStats(this, stats);
+    }
   }
 };
 </script>

--- a/assets/js/search/components/searches/TopicSearch.vue
+++ b/assets/js/search/components/searches/TopicSearch.vue
@@ -32,6 +32,7 @@
           :from="0"
           :size="10"
           :showResultStats="true"
+          :renderResultStats="customRenderStats"
           class="result-list-container"
           :react="{ and: ['Search', 'Study'] }"
           renderNoResults="No Topics found. Try to change your search query or filter options."
@@ -61,6 +62,11 @@ export default {
   components: {
     StudyFacet,
     TopicResult
+  },
+  methods: {
+    customRenderStats(stats) {
+      return helpers.customRenderStats(this, stats);
+    }
   }
 };
 </script>

--- a/assets/js/search/components/searches/VariableSearch.vue
+++ b/assets/js/search/components/searches/VariableSearch.vue
@@ -20,12 +20,8 @@
         <!-- begin facets -->
         <study-facet :react="{ and: ['AnalysisUnit', 'ConceptualDataset', 'Period', 'Search'] }" />
         <conceptual-dataset-facet :react="{ and: ['AnalysisUnit', 'Period','Search', 'Study'] }" />
-        <analysis-unit-facet
-          :react="{ and: ['ConceptualDataset', 'Period', 'Search', 'Study'] }"
-        />
-        <period-facet
-          :react="{ and: ['AnalysisUnit', 'ConceptualDataset', 'Search', 'Study'] }"
-        />
+        <analysis-unit-facet :react="{ and: ['ConceptualDataset', 'Period', 'Search', 'Study'] }" />
+        <period-facet :react="{ and: ['AnalysisUnit', 'ConceptualDataset', 'Search', 'Study'] }" />
         <!-- end facets -->
       </div>
       <div class="col-lg-8 m-0 p-0 float-right">
@@ -37,6 +33,7 @@
           :from="0"
           :size="10"
           :showResultStats="true"
+          :renderResultStats="customRenderStats"
           class="result-list-container"
           :react="{ and: ['AnalysisUnit', 'ConceptualDataset', 'Period', 'Search', 'Study'] }"
           renderNoResults="No Variables found. Try to change your search query or filter options."
@@ -87,6 +84,11 @@ export default {
     PeriodFacet,
     StudyFacet,
     VariableResult
+  },
+  methods: {
+    customRenderStats(stats) {
+      return helpers.customRenderStats(this, stats);
+    }
   }
 };
 </script>

--- a/assets/js/search/components/searches/helpers.js
+++ b/assets/js/search/components/searches/helpers.js
@@ -1,9 +1,4 @@
 /**
- * Returns the index name depending on the state of the PREFIX envvar.
- *
- * This is used to separate standard use indices from test indices.
- * It is intended to be altered during the build by webpack.
- *
  * @author: Dominique Hansen
  * @copyright: 2019 Dominique Hansen (DIW Berlin)
  * @license: AGPL-3.0 GNU AFFERO GENERAL PUBLIC LICENSE (AGPL) 3.0.
@@ -11,8 +6,16 @@
  *  [reporitory](https://github.com/ddionrails/ddionrails/blob/master/LICENSE.md)
  *  or at
  *  https://www.gnu.org/licenses/agpl-3.0.txt
+*/
+
+
+/**
+ * Returns the index name depending on the state of the PREFIX envvar.
  *
- * @param {string} baseName base part of the index name
+ * This is used to separate standard use indices from test indices.
+ * It is intended to be altered during the build by webpack.
+ *
+ * @param {string} baseName Base part of the index name
  * @return {string} Full name of the index to be used.
  */
 export function indexNameSwitch(baseName) {
@@ -22,3 +25,33 @@ export function indexNameSwitch(baseName) {
     return baseName;
   }
 }
+
+
+/**
+ * Customizes the result text displayed after a search.
+ *
+ * Elasticsearch by default only returns 10000 results.
+ * Other sections of the UI do however show numbers greater than 10000
+ * for the number of entities inside the search index.
+ * This dissonance in numbers could be confusing.
+ * To make it more clear, that more than 10000 results exist, the message
+ * is customized here to say "More than 10000 results found ...", instead of
+ * "10000 results found ...".
+ *
+ * @param {object} vueInstance Vue instance from which this function is called.
+ * @param {object} stats Contains quantitative data about the search results.
+ * @return {VNode} A paragraph VNode with the result text.
+ */
+export function customRenderStats(vueInstance, stats) {
+  const h = vueInstance.$createElement;
+  return h("p", {
+    "class": "css-1e7votj",
+  },
+  [
+    stats.totalResults>=10000?"More than ":"",
+    stats.totalResults,
+    " results found in ",
+    stats.time,
+    "ms",
+  ]);
+};


### PR DESCRIPTION
Elasticsearch 7 by default only returns 10000 results.
Other sections of the UI do however show numbers greater than 10000
for the number of entities inside the search index.
This dissonance in numbers could be confusing.
To make it more clear, that more than 10000 results exist, the message
is customized here to say "More than 10000 results found ...",
instead of "10000 results found ...".