### PR TITLE
-FIX- Make postfix version pin less strict

### DIFF
--- a/docker/postfix/Dockerfile
+++ b/docker/postfix/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10.2
 
-RUN apk add --no-cache postfix=3.4.5-r0
+RUN apk add --no-cache 'postfix=~3'
 
 RUN echo "mynetworks = 172.16.238.10" >> /etc/postfix/main.cf
 


### PR DESCRIPTION
Pinned postfix version was no longer available
after update of alpine version.