### PR TITLE
Refactor Variable Model

### DIFF
--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -205,10 +205,13 @@ class Variable(ModelMixin, models.Model):
         """ Return a markdown rendered version of the "description_long" field """
         try:
             html = render_markdown(self.description_long)
-        except UnicodeDecodeError:
+        # The markdown.markdown function used by render markdown can potentially
+        # raise these errors. But I did not find any input, that triggered errors.
+        # They also exclude these except blocks from coverage themselves.
+        except UnicodeDecodeError:  # pragma: no cover
             LOGGER.debug("Encoding error in long description: %s", self.description_long)
             html = ""
-        except ValueError:
+        except ValueError:  # pragma: no cover
             LOGGER.debug(
                 "Cannot perform basic string operations on long description: %s",
                 self.description_long,

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 import uuid
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
@@ -29,6 +30,8 @@ from .dataset import Dataset
 # Exclude this from test coverage since its not related to functionality.
 if TYPE_CHECKING:  # pragma: no cover
     from ddionrails.instruments.models.question import Question
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Variable(ModelMixin, models.Model):
@@ -202,7 +205,14 @@ class Variable(ModelMixin, models.Model):
         """ Return a markdown rendered version of the "description_long" field """
         try:
             html = render_markdown(self.description_long)
-        except:  # TODO: what could happen in render_markdown() ?
+        except UnicodeDecodeError:
+            LOGGER.debug("Encoding error in long description: %s", self.description_long)
+            html = ""
+        except ValueError:
+            LOGGER.debug(
+                "Cannot perform basic string operations on long description: %s",
+                self.description_long,
+            )
             html = ""
         return html
 

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -25,7 +25,8 @@ from .dataset import Dataset
 
 # Workaround to prevent cyclic importing.
 # Refactoring of data and instrument app might be necessary to remove this.
-if TYPE_CHECKING:
+# Exclude this from test coverage since its not related to functionality.
+if TYPE_CHECKING:  # pragma: no cover
     from ddionrails.instruments.models.question import Question
 
 

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -281,14 +281,6 @@ class Variable(ModelMixin, models.Model):
     def _period_model_to_name_dict(instances: List[Period]) -> Dict[Dict[str, Any]]:
         return {instance.id: instance.name for instance in instances}
 
-    def has_origin_variables(self) -> bool:
-        """
-        TEMPORARY / DEPRECATED
-
-        Find a better solution, when to show origin variables…
-        """
-        return self.origin_variables.count() > 0
-
     @staticmethod
     def _get_related_variable_information(objects: Union[List[Variable], List[Question]]):
         """Get objects related through transformations

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -376,8 +376,8 @@ class Variable(ModelMixin, models.Model):
         """ Returns True if the variable has categories """
         return len(self.categories) > 0
 
-    # TODO: is this even in use?
-    def to_dict(self) -> Dict:
+    @property
+    def as_dict(self) -> Dict:
         """ Returns a dictionary representation of the Variable object """
         return dict(
             name=self.name,

--- a/ddionrails/data/views.py
+++ b/ddionrails/data/views.py
@@ -144,4 +144,4 @@ def variable_json(
         dataset__name=dataset_name,
         name=variable_name,
     )
-    return JsonResponse(variable.to_dict())
+    return JsonResponse(variable.as_dict)

--- a/ddionrails/data/views.py
+++ b/ddionrails/data/views.py
@@ -144,4 +144,4 @@ def variable_json(
         dataset__name=dataset_name,
         name=variable_name,
     )
-    return JsonResponse(variable.as_dict)
+    return JsonResponse(variable.content_dict)

--- a/templates/data/variable_detail.html
+++ b/templates/data/variable_detail.html
@@ -73,8 +73,8 @@
                         {% include "data/related_variables.html" with variable_list=variable.get_related_variables_by_period %}
                     </div>
                     <div role="tabpanel" class="tab-pane" id="origin_variables">
-                        {% if variable.get_origin_variables %}
-                            {% for study, variable_list in variable.get_origin_variables.items %}
+                        {% if variable.origin_variables_dict %}
+                            {% for study, variable_list in variable.origin_variables_dict.items %}
                                 {% include "data/related_variables.html" with table_name=study.title %}
                             {% endfor %}
                         {% else %}
@@ -82,8 +82,8 @@
                         {% endif %}
                     </div>
                     <div role="tabpanel" class="tab-pane" id="target_variables">
-                        {% if variable.get_target_variables %}
-                            {% for study, variable_list in variable.get_target_variables.items %}
+                        {% if variable.target_variables_dict %}
+                            {% for study, variable_list in variable.target_variables_dict.items %}
                                 {% include "data/related_variables.html" with table_name=study.title %}
                             {% endfor %}
                         {% else %}

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -3,6 +3,8 @@
 
 """ Test cases for models in ddionrails.data app """
 
+import unittest
+
 import pytest
 
 from ddionrails.data.models import Variable
@@ -20,6 +22,28 @@ def _related_variables_by_concept(variable, concept):
     other_variable.concept = concept
     other_variable.save()
     return variable, other_variable
+
+
+class TestVariable(unittest.TestCase):
+    def test_sorting(self):
+        """Variables should be sortable by their name."""
+        first_variable = Variable()
+        first_variable.name = "a"
+        second_variable = Variable()
+        second_variable.name = "z"
+        variables = [second_variable, first_variable]
+        variables.sort()
+        self.assertEqual(first_variable, variables[0])
+        self.assertEqual(second_variable, variables[1])
+
+    def test_sorting_error(self):
+        first_variable = Variable()
+        first_variable.name = "a"
+        second_variable = "z"
+        variables = [second_variable, first_variable]
+
+        with self.assertRaises(TypeError):
+            variables.sort()
 
 
 class TestVariableModel:

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -3,9 +3,7 @@
 
 """ Test cases for models in ddionrails.data app """
 
-import logging
 import unittest
-from io import StringIO
 
 import pytest
 

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -181,7 +181,7 @@ class TestVariableModel:
         assert expected == result
 
     def test_to_dict(self, variable):
-        result = variable.to_dict()
+        result = variable.as_dict
         assert result["name"] == variable.name
         assert result["scale"] == variable.scale
         assert result["uni"] == variable.categories


### PR DESCRIPTION
* get_target_by_study_and_period and
  get_origin_by_study_and_period contained almost
  100% redundant code.
* Redundant code was migrated to private function.
* Private function _get_related_object_information
  is now called from both functions with their
  differing input.