### PR TITLE
Fix data backup

### DIFF
--- a/ddionrails/workspace/management/commands/restore.py
+++ b/ddionrails/workspace/management/commands/restore.py
@@ -3,10 +3,10 @@
 """ Management command to restore user data for ddionrails.workspace app """
 
 import pathlib
+import sys
 
 import djclick as click
 import tablib
-from import_export.formats.base_formats import CSV, JSON, YAML, TextFormat
 
 from ddionrails.workspace.resources import determine_model_and_resource
 
@@ -20,31 +20,19 @@ def get_recent_backup_directory():
         return paths[-1]
     except (FileNotFoundError, IndexError):
         click.secho("No backup to restore", fg="red")
-        exit()
-
-
-def determine_import_format(format_: str) -> TextFormat:
-    """ Determine which format to use for import """
-    if format_ == "csv":
-        return CSV
-    if format_ == "json":
-        return JSON
-    if format_ == "yaml":
-        return YAML
+        sys.exit()
 
 
 def restore_entity(entity: str, path: pathlib.Path, format_: str) -> None:
     """ Restore data from file in given path with given format """
-    resource = determine_model_and_resource(entity, method="restore")[1]
+    _, resource = determine_model_and_resource(entity, method="restore")
     filename = (path / entity).with_suffix("." + format_)
     try:
         with open(str(filename), "r") as infile:
-            data = infile.read()
+            dataset = tablib.Dataset().load(infile.read())
     except FileNotFoundError:
         click.secho(f"No backup to restore for {entity}", fg="red")
         return
-    import_format = determine_import_format(format_)
-    dataset = import_format().create_dataset(data)
 
     # Try to import the data in dry_run mode
     result = resource().import_data(dataset, dry_run=True)
@@ -52,21 +40,25 @@ def restore_entity(entity: str, path: pathlib.Path, format_: str) -> None:
         output = tablib.Dataset()
         output.headers = ["basket", "user", "email", "study", "dataset", "variable"]
         click.secho(f"Error while importing {entity} from {filename}", fg="red")
-        for line, errors in result.row_errors():
-            for error in errors:
-                click.secho(
-                    f"Error in line: {line}, {error.error}, {error.row}", fg="red"
-                )
-                output.append(error.row.values())
+        if result.row_errors():
+            _print_errors(result.row_errors(), output)
         log_file = path / "error_log.csv"
         with open(str(log_file), "w") as outfile:
-            outfile.write(output.csv)
+            outfile.write(output.export("csv"))
     else:
         # Actually write the data to the database if no errors were encountered in dry run
         resource().import_data(dataset, dry_run=False)
         click.secho(
             f"Succesfully imported {len(dataset)} {entity} from {filename}", fg="green"
         )
+
+
+def _print_errors(error_information: tuple, dataset: tablib.Dataset):
+    """Handle error output for restore_entity function"""
+    for line, errors in error_information:
+        for error in errors:
+            click.secho(f"Error in line: {line}, {error.error}, {error.row}", fg="red")
+            dataset.append(error.row.values())
 
 
 @click.command()
@@ -76,7 +68,7 @@ def restore_entity(entity: str, path: pathlib.Path, format_: str) -> None:
 @click.option("-s", "--scripts", default=False, is_flag=True)
 @click.option("-f", "--format", "format_", default="csv")
 @click.option("-p", "--path", "path", default="local/backup")
-def command(
+def command(  # pylint: disable=too-many-arguments
     users: bool,
     baskets: bool,
     basket_variables: bool,
@@ -88,23 +80,23 @@ def command(
     if path == "local/backup":
         path = get_recent_backup_directory()
 
-    path = pathlib.Path(path)
+    _path: pathlib.Path = pathlib.Path(path)
 
     if users:
-        restore_entity("users", path, format_)
+        restore_entity("users", _path, format_)
 
     if baskets:
-        restore_entity("baskets", path, format_)
+        restore_entity("baskets", _path, format_)
 
     if basket_variables:
-        restore_entity("basket_variables", path, format_)
+        restore_entity("basket_variables", _path, format_)
 
     if scripts:
-        restore_entity("scripts", path, format_)
+        restore_entity("scripts", _path, format_)
 
     # If no command line argument is given, backup all entities
     if any((users, baskets, basket_variables, scripts)) is False:
-        restore_entity("users", path, format_)
-        restore_entity("baskets", path, format_)
-        restore_entity("basket_variables", path, format_)
-        restore_entity("scripts", path, format_)
+        restore_entity("users", _path, format_)
+        restore_entity("baskets", _path, format_)
+        restore_entity("basket_variables", _path, format_)
+        restore_entity("scripts", _path, format_)


### PR DESCRIPTION
* Update in external tablib library broke
  functionality in workspace.management.commands.restore

  + restore managed identification of input file format
    (CSV, JSON, YAML)
  + tablib now manages file format identification and
    does not support the former ways to specify file
    formats.

* Remove local file format identification and
  let tablib handle identification.
* Removed some lint