### PR TITLE
Limit LabelTable size

### DIFF
--- a/ddionrails/data/helpers.py
+++ b/ddionrails/data/helpers.py
@@ -122,16 +122,14 @@ class LabelTable:
                     row.append(None)
             table["body"][category_label] = row
 
-    def _get_all_category_labels(self):
-        categories: Dict[str, List[str]] = defaultdict(list)
+    def _get_all_category_labels(self) -> Dict[str, List[str]]:
+        labels: Dict[str, List[str]] = defaultdict(list)
         for variable in self.variables:
             for category in variable.get_categories():
-                categories[self._simplify_label(category["label"])].append(
-                    category["value"]
-                )
-            if _label_count := len(categories) > self.label_max:
-                self.label_count = _label_count
-                return {}
+                labels[self._simplify_label(category["label"])].append(category["value"])
+            if len(labels) > self.label_max:
+                self.label_count = len(labels)
+                return dict()
 
         def sort_helper(elements):
             temp_list = list()
@@ -149,9 +147,9 @@ class LabelTable:
             except ZeroDivisionError:
                 return 100000000
 
-        categories = sorted(list(categories.items()), key=sort_helper)
-        categories = [category[0] for category in categories]
-        return categories
+        labels = sorted(list(labels.items()), key=sort_helper)
+        labels = [category[0] for category in labels]
+        return labels
 
     @staticmethod
     def _simplify_label(label):

--- a/ddionrails/data/helpers.py
+++ b/ddionrails/data/helpers.py
@@ -6,8 +6,6 @@ import re
 from collections import OrderedDict, defaultdict
 from typing import List
 
-from django.utils.functional import cached_property
-
 from ddionrails.data.models.variable import Variable
 
 LABEL_RE_SOEP = re.compile(r"\s*\[[\w\d\-]*\]\s*")
@@ -64,7 +62,6 @@ class LabelTable:
         self._fill_body(table)
         return table
 
-    @cached_property
     def to_html(self):
         if not self.render_table:
             return ""

--- a/ddionrails/data/helpers.py
+++ b/ddionrails/data/helpers.py
@@ -4,7 +4,6 @@
 
 import re
 from collections import OrderedDict, defaultdict
-from itertools import islice
 from typing import List
 
 from django.utils.functional import cached_property

--- a/ddionrails/data/helpers.py
+++ b/ddionrails/data/helpers.py
@@ -45,6 +45,8 @@ class LabelTable:
         else:
             self.variables = sorted(variables, key=sort_helper)
 
+        self.category_labels = self._get_all_category_labels()
+
     @property
     def render_table(self) -> bool:
         """Determine if Table should be rendered in html."""
@@ -106,7 +108,7 @@ class LabelTable:
             table["header"].append(variable)
 
     def _fill_body(self, table):
-        for category_label in self._get_all_category_labels():
+        for category_label in self.category_labels:
             row = list()
             for variable in self.variables:
                 try:

--- a/ddionrails/data/helpers.py
+++ b/ddionrails/data/helpers.py
@@ -4,7 +4,7 @@
 
 import re
 from collections import OrderedDict, defaultdict
-from typing import List
+from typing import Dict, List
 
 from ddionrails.data.models.variable import Variable
 
@@ -46,7 +46,8 @@ class LabelTable:
             self.variables = sorted(variables, key=sort_helper)
 
     @property
-    def render_table(self):
+    def render_table(self) -> bool:
+        """Determine if Table should be rendered in html."""
         if not self.variables:
             return False
         if self.label_count > self.label_max:
@@ -63,6 +64,7 @@ class LabelTable:
         return table
 
     def to_html(self):
+        """Create a string representing the table as html table."""
         if not self.render_table:
             return ""
         label_dict = self.to_dict()
@@ -105,7 +107,7 @@ class LabelTable:
 
     def _fill_body(self, table):
         for category_label in self._get_all_category_labels():
-            x = []
+            row = list()
             for variable in self.variables:
                 try:
                     category = [
@@ -113,15 +115,15 @@ class LabelTable:
                         for c in variable.get_categories()
                         if self._simplify_label(c["label"]) == category_label
                     ][0]
-                    x.append(
+                    row.append(
                         dict(value=category["value"], frequency=category["frequency"])
                     )
                 except:
-                    x.append(None)
-            table["body"][category_label] = x
+                    row.append(None)
+            table["body"][category_label] = row
 
     def _get_all_category_labels(self):
-        categories = defaultdict(list)
+        categories: Dict[str, List[str]] = defaultdict(list)
         for variable in self.variables:
             for category in variable.get_categories():
                 categories[self._simplify_label(category["label"])].append(
@@ -131,13 +133,14 @@ class LabelTable:
                 self.label_count = _label_count
                 return {}
 
-        def sort_helper(x):
-            temp_list = []
-            for x in x[1]:
-                if x and x != "":
+        def sort_helper(elements):
+            temp_list = list()
+            for element in elements[1]:
+                if element and element != "":
                     try:
-                        temp_list.append(int(x))
-                    # afuetterer: the int(x) might fail, when x is not castable to an integer?
+                        temp_list.append(int(element))
+                    # afuetterer: the int(x) might fail,
+                    # when x is cannot be cast to an integer?
                     except ValueError:
                         pass
             try:
@@ -152,10 +155,8 @@ class LabelTable:
 
     @staticmethod
     def _simplify_label(label):
-        try:
-            label = label.lower().strip()
-            label = LABEL_RE_SOEP.sub("", label)
-            label = LABEL_RE_PAIRFAM.sub("", label)
-            return label
-        except:
-            return ""
+        label = str(label)
+        label = label.lower().strip()
+        label = LABEL_RE_SOEP.sub("", label)
+        label = LABEL_RE_PAIRFAM.sub("", label)
+        return label

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -267,7 +267,7 @@ class Variable(ModelMixin, models.Model):
         ):
             if self.concept:
                 variables = Variable.objects.select_related(
-                    "dataset", "dataset__study"
+                    "dataset", "dataset__study", "period"
                 ).filter(concept=self.concept, dataset__study=self.dataset.study)
                 self.related_cache = self.Cache(id=self.concept.id, content=variables)
             else:

--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -223,15 +223,16 @@ class Variable(ModelMixin, models.Model):
         """ Return a list of dictionaries based on the "categories" field """
         if self.categories:
             categories = []
+            if "labels_de" not in self.categories:
+                self.categories["labels_de"] = self.categories["labels"]
             for index, _ in enumerate(self.categories["values"]):
                 category = dict(
                     value=self.categories["values"][index],
                     label=self.categories["labels"][index],
                     frequency=self.categories["frequencies"][index],
                     valid=(not self.categories["missings"][index]),
+                    label_de=self.categories["labels_de"][index],
                 )
-                if "labels_de" in self.categories:
-                    category["label_de"] = self.categories["labels_de"][index]
                 categories.append(category)
             return categories
 

--- a/templates/data/variable_detail.html
+++ b/templates/data/variable_detail.html
@@ -142,18 +142,20 @@
         </div>
     </div>
     {% if label_table %}
-        <h2>Label table</h2>
-        <p>The label table provides you with an overview of label definitions across
-            related variables to identify changes over time in longitudinal variables.
-            The first number indicates the value code, the second number (in brackets)
-            represents the frequency in the data. Please note that labels are simplified
-            and values with frequency = 0 are hidden.</p>
-        <!-- End content -->
-        <div class="table-responsive">
-            {{ label_table.to_html | safe }}
-        </div>
-        <div class="content">
-        <!-- Restart content -->
+        {% if label_table.render_table %}
+            <h2>Label table</h2>
+            <p>The label table provides you with an overview of label definitions across
+                related variables to identify changes over time in longitudinal variables.
+                The first number indicates the value code, the second number (in brackets)
+                represents the frequency in the data. Please note that labels are simplified
+                and values with frequency = 0 are hidden.</p>
+            <!-- End content -->
+            <div class="table-responsive">
+                {{ label_table.to_html | safe }}
+            </div>
+            <div class="content">
+            <!-- Restart content -->
+        {% endif %}
     {% endif %}
 {% endblock content %}
 {% block scripts %}

--- a/tests/data/test_helpers.py
+++ b/tests/data/test_helpers.py
@@ -38,6 +38,9 @@ def label_table(variables):
 class TestLabelTable:
     def test_init_method(self, variables):
         """ The init method of the label table sorts the variables by their datasets periods """
+        # Save teh variables to get their period data from the dataset.
+        for variable in variables:
+            variable.save()
         label_table = LabelTable(variables)
         variables.reverse()
         assert label_table.variables == variables

--- a/tests/data/test_helpers.py
+++ b/tests/data/test_helpers.py
@@ -60,13 +60,59 @@ class TestLabelTable:
         for number in range(0, 101):
             categories.append({"label": uuid4(), "value": number})
 
+        # To use unittest assertions with this pytest setup.
+        # Class should be refactored to inherit TestCase if time can be allocated.
+        test = TestCase()
+
         with patch(
             "ddionrails.data.models.variable.Variable.get_categories",
             return_value=categories,
         ):
             label_table = LabelTable(variables)
-            label_table.to_html()
-            TestCase().assertFalse(label_table.render_table)
+            test.assertFalse(label_table.render_table)
+            test.assertEqual("", label_table.to_html())
+
+    def test_variable_render_limit(self, variables):
+        """LabelTable should not be rendered for more than 100 variables.
+
+        The creation of the HTML of the LabelTable is to time consuming for large
+        numbers of related variables.
+        """
+
+        # To use unittest assertions with this pytest setup.
+        # Class should be refactored to inherit TestCase if time can be allocated.
+        test = TestCase()
+
+        for _ in range(0, 100):
+            variables.append(variables[0])
+        label_table = LabelTable(variables)
+        # Do not render a LabelTable if variable count exceeds the limit.
+        test.assertFalse(label_table.render_table)
+        # Throw away all variables for the LabelTable if their number exceeds
+        # the limit.
+        test.assertEqual(list(), label_table.variables)
+
+    def test_to_html(self, variables):
+        """LabelTable should not be rendered for variable with more than 100 labels.
+
+        The creation of the HTML of the LabelTable is to time consuming for large
+        numbers of labels.
+        """
+
+        categories = list()
+        for number in range(0, 5):
+            categories.append({"label": uuid4(), "value": number})
+
+        test = TestCase()
+
+        with patch(
+            "ddionrails.data.models.variable.Variable.get_categories",
+            return_value=categories,
+        ):
+            label_table = LabelTable(variables)
+            html_output = label_table.to_html()
+            for variable in variables:
+                test.assertIn(variable.name, html_output)
 
     def test_init_method_without_period(self, variables):
         """ The first variable has no period in this test """

--- a/tests/data/test_models.py
+++ b/tests/data/test_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=missing-docstring,no-self-use,invalid-name
+# pylint: disable=missing-docstring,no-self-use,invalid-name,too-many-public-methods
 
 """ Test cases for models in ddionrails.data app """
 
@@ -210,6 +210,7 @@ class TestVariableModel:
         expected = {
             "value": "-6",
             "label": "[-6] Version of questionnaire with modified filtering",
+            "label_de": "[-6] Version of questionnaire with modified filtering",
             "frequency": 1,
             "valid": False,
         }


### PR DESCRIPTION
Problem
-------

A variable with many value labels and/or many
related variables would cause a server timeout.
This is caused by the generation of a string
containing HTML that is rendered by a LabelTable
instance.

Solution
--------

Stop the LabelTable from rendering if a variable
has more than 100 related variables or more than a
100 value labels.