### PR TITLE
Change variable detail data to be displayed

### DIFF
--- a/ddionrails/data/models/variable.py
+++ b/ddionrails/data/models/variable.py
@@ -201,10 +201,10 @@ class Variable(ModelMixin, models.Model):
         """ Return a QuerySet of Variable objects by a given concept id """
         return cls.objects.filter(concept_id=concept_id)
 
-    def html_description_long(self) -> str:
+    def html_description(self) -> str:
         """ Return a markdown rendered version of the "description_long" field """
         try:
-            html = render_markdown(self.description_long)
+            html = render_markdown(self.description)
         # The markdown.markdown function used by render markdown can potentially
         # raise these errors. But I did not find any input, that triggered errors.
         # They also exclude these except blocks from coverage themselves.

--- a/templates/data/variable_info.html
+++ b/templates/data/variable_info.html
@@ -23,7 +23,7 @@
             {{ variable.html_description | safe }}
         </p>
         <p>
-            {{ variable.html_description_long | safe }}
+            {{ variable.html_description | safe }}
         </p>
         <hr>
         <p><b>Analysis unit:</b>


### PR DESCRIPTION
* Field description_long was used for the information
  displayed inside variable detail section.
* Changed to field description.