### PR TITLE
Fix display of dataTables

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -28,3 +28,11 @@ if (ieTen > 0 || ieEleven > 0) {
   const warning = document.getElementById("windowsWarning");
   warning.classList.remove("hidden");
 }
+
+$("document").ready(
+  function() {
+    for (const table of $(".datatable")) {
+      table.dataTable();
+    }
+  }
+);

--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -83,7 +83,7 @@ i {
  Datatables general styling
 **************************/
 
-#dataset_table_filter {
+.dataTables_filter {
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
* Tables where not instantiated as dataTables.
* Alignment of dataTable search input field was misaligned
  when more than one dataTable was present.