### PR TITLE
Add method to handle abandoned concepts

### DIFF
--- a/ddionrails/base/mixins.py
+++ b/ddionrails/base/mixins.py
@@ -111,10 +111,9 @@ class ModelMixin:
         label = getattr(self, "label", "")
         if self.language == "de":
             label = getattr(self, "label_de", "")
-        if label is not None and label != "":
+        if label:
             return str(label)
-        else:
-            return str(name)
+        return str(name)
 
     def html_description(self):
         """
@@ -139,7 +138,7 @@ class ModelMixin:
         return "/".join(result)
 
 
-class ImportPathMixin:
+class ImportPathMixin:  # pylint: disable=R0903
     """ A mixin for models to return an import_path based on their name attribute """
 
     def import_path(self) -> pathlib.Path:

--- a/ddionrails/concepts/imports.py
+++ b/ddionrails/concepts/imports.py
@@ -5,6 +5,8 @@
 import json
 import logging
 
+from django.db.transaction import atomic
+
 from ddionrails.imports import imports
 
 from .forms import (
@@ -54,6 +56,10 @@ class ConceptImport(imports.CSVImport):
     class DOR:  # pylint: disable=missing-docstring,too-few-public-methods
         form = ConceptForm
 
+    @atomic
+    def execute_import(self):
+        super().execute_import()
+
     def import_element(self, element):
         new_concept = super().import_element(element)
         topic_name = element.get("topic_name", None)
@@ -63,7 +69,10 @@ class ConceptImport(imports.CSVImport):
                 topic.concepts.add(new_concept)
             except:
                 logger.error(
-                    f'Could not link concept "{new_concept.name}"" to topic "{topic_name}"'
+                    (
+                        "Could not link concept "
+                        f'"{new_concept.name}"" to topic "{topic_name}"'
+                    )
                 )
         return new_concept
 

--- a/ddionrails/imports/imports.py
+++ b/ddionrails/imports/imports.py
@@ -4,12 +4,15 @@
 
 import logging
 import os
+from pathlib import Path
 from typing import Iterable, Union
 
 import frontmatter
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.forms import Form
+
+from ddionrails.studies.models import Study
 
 from .helpers import read_csv
 
@@ -26,7 +29,7 @@ class Import:
 
     content: Union[None, str, Iterable]
 
-    def __init__(self, filename, study=None, system=None):
+    def __init__(self, filename: Union[Path, str], study: Study = None, system=None):
         self.study = study
         self.system = system
         self.filename = filename

--- a/ddionrails/imports/management/commands/update.py
+++ b/ddionrails/imports/management/commands/update.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
 
         # if no study_name is given, update all studies
         if study_name == "all":
-            self.log_success(f"Updating all studies")
+            self.log_success("Updating all studies")
             update_all_studies_completely(local, clean_import)
             sys.exit(0)
 

--- a/tests/functional/imports/test_imports.py
+++ b/tests/functional/imports/test_imports.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring,no-self-use
 
+import unittest
 from pathlib import Path
 
 import pytest
-from elasticsearch_dsl import Search
+from django.core.management import call_command
 
 from ddionrails.concepts.documents import ConceptDocument
 from ddionrails.concepts.models import (
@@ -29,252 +30,276 @@ from ddionrails.publications.models import Attachment, Publication
 from ddionrails.studies.models import Study, TopicList
 from tests.data.factories import VariableFactory
 
+TEST_CASE = unittest.TestCase()
+
 pytestmark = [  # pylint: disable=invalid-name
     pytest.mark.functional,
     pytest.mark.filterwarnings("ignore::DeprecationWarning"),
 ]
 
 
-@pytest.fixture
-def study_import_manager(study, settings):
+@pytest.fixture(name="study_import_manager")
+def _study_import_manager(study, settings):
     settings.IMPORT_REPO_PATH = Path("tests/functional/test_data/")
     manager = StudyImportManager(study)
     return manager
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mock_import_path")
 class TestStudyImportManager:
     def test_import_study(self, study_import_manager):  # pylint: disable=unused-argument
         study_import_manager.import_single_entity("study")
-        assert 1 == Study.objects.count()
+        TEST_CASE.assertEqual(1, Study.objects.count())
         # refresh
         study = Study.objects.first()
-        assert "Some Study" == study.label
-        assert {"variables": {"label-table": True}} == study.config
+        TEST_CASE.assertEqual("Some Study", study.label)
+        TEST_CASE.assertEqual({"variables": {"label-table": True}}, study.config)
 
     def test_import_csv_topics(self, study_import_manager):
-        assert 0 == Topic.objects.count()
+        TEST_CASE.assertEqual(0, Topic.objects.count())
         study_import_manager.import_single_entity("topics.csv")
-        assert 2 == Topic.objects.count()
+        TEST_CASE.assertEqual(2, Topic.objects.count())
         topic = Topic.objects.get(name="some-topic")
         parent_topic = Topic.objects.get(name="some-other-topic")
-        assert "some-topic" == topic.label
-        assert parent_topic == topic.parent
-        assert "some-other-topic" == parent_topic.label
+        TEST_CASE.assertEqual("some-topic", topic.label)
+        TEST_CASE.assertEqual(parent_topic, topic.parent)
+        TEST_CASE.assertEqual("some-other-topic", parent_topic.label)
 
     def test_import_json_topics(
         self, study_import_manager
     ):  # pylint: disable=unused-argument
-        assert 1 == Study.objects.count()
-        assert 0 == Topic.objects.count()
-        assert 0 == TopicList.objects.count()
+        TEST_CASE.assertEqual(1, Study.objects.count())
+        TEST_CASE.assertEqual(0, Topic.objects.count())
+        TEST_CASE.assertEqual(0, TopicList.objects.count())
         study_import_manager.import_single_entity("study")
         study_import_manager.import_single_entity("topics.json")
-        assert 1 == Study.objects.count()
-        assert 1 == TopicList.objects.count()
+        TEST_CASE.assertEqual(1, Study.objects.count())
+        TEST_CASE.assertEqual(1, TopicList.objects.count())
         study = Study.objects.first()
         topiclist = TopicList.objects.first()
-        assert study == topiclist.study
+        TEST_CASE.assertEqual(study, topiclist.study)
         english_topics = topiclist.topiclist[0]
-        assert "en" == english_topics["language"]
+        TEST_CASE.assertEqual("en", english_topics["language"])
         german_topics = topiclist.topiclist[1]
-        assert "de" == german_topics["language"]
+        TEST_CASE.assertEqual("de", german_topics["language"])
 
-    def test_import_concepts(self, study_import_manager, elasticsearch_indices, topic):
-        assert 0 == Concept.objects.count()
-        study_import_manager.import_single_entity("concepts")
-        assert 1 == Concept.objects.count()
-        concept = Concept.objects.first()
-        assert "some-concept" == concept.name
-        assert "Some concept" == concept.label
-        assert topic == concept.topics.first()
+    @pytest.mark.usefixtures(("elasticsearch_indices"))
+    def test_import_concepts(self, study, topic):
+        TEST_CASE.assertEqual(0, Concept.objects.count())
+        with TEST_CASE.assertRaises(SystemExit) as _exit:
+            call_command("update", study.name, "concepts", "-l")
+            TEST_CASE.assertEqual(0, _exit.exception.code)
+        # concepts.csv will be extended through one concept from the variables.csv
+        TEST_CASE.assertEqual(2, Concept.objects.count())
+        concept = Concept.objects.filter(name="some-concept").first()
+        TEST_CASE.assertEqual("some-concept", concept.name)
+        TEST_CASE.assertEqual("Some concept", concept.label)
+        TEST_CASE.assertEqual(topic, concept.topics.first())
 
         search = ConceptDocument.search().query("match_all")
-        assert 1 == search.count()
+        TEST_CASE.assertEqual(2, search.count())
         response = search.execute()
-        hit = response.hits[0]
-        assert "some-concept" == hit.name
+        TEST_CASE.assertIn("some-concept", [hit.name for hit in response.hits])
         ConceptDocument.search().query("match_all").delete()
 
     def test_import_analysis_units(self, study_import_manager):
-        assert 0 == AnalysisUnit.objects.count()
+        TEST_CASE.assertEqual(0, AnalysisUnit.objects.count())
         study_import_manager.import_single_entity("analysis_units")
-        assert 1 == AnalysisUnit.objects.count()
+        TEST_CASE.assertEqual(1, AnalysisUnit.objects.count())
         analysis_unit = AnalysisUnit.objects.first()
-        assert "some-analysis-unit" == analysis_unit.name
-        assert "some-analysis-unit" == analysis_unit.label
-        assert "some-analysis-unit" == analysis_unit.description
+        TEST_CASE.assertEqual("some-analysis-unit", analysis_unit.name)
+        TEST_CASE.assertEqual("some-analysis-unit", analysis_unit.label)
+        TEST_CASE.assertEqual("some-analysis-unit", analysis_unit.description)
 
     def test_import_periods(self, study_import_manager, study):
-        assert 0 == Period.objects.count()
+        TEST_CASE.assertEqual(0, Period.objects.count())
         study_import_manager.import_single_entity("periods")
-        assert 1 == Period.objects.count()
+        TEST_CASE.assertEqual(1, Period.objects.count())
         period = Period.objects.first()
-        assert "some-period" == period.name
-        assert "some-period" == period.label
-        assert study == period.study
+        TEST_CASE.assertEqual("some-period", period.name)
+        TEST_CASE.assertEqual("some-period", period.label)
+        TEST_CASE.assertEqual(study, period.study)
 
     def test_import_conceptual_datasets(self, study_import_manager):
-        assert 0 == ConceptualDataset.objects.count()
+        TEST_CASE.assertEqual(0, ConceptualDataset.objects.count())
         study_import_manager.import_single_entity("conceptual_datasets")
-        assert 1 == ConceptualDataset.objects.count()
+        TEST_CASE.assertEqual(1, ConceptualDataset.objects.count())
         conceptual_dataset = ConceptualDataset.objects.first()
-        assert "some-conceptual-dataset" == conceptual_dataset.name
-        assert "some-conceptual-dataset" == conceptual_dataset.label
-        assert "some-conceptual-dataset" == conceptual_dataset.description
+        TEST_CASE.assertEqual("some-conceptual-dataset", conceptual_dataset.name)
+        TEST_CASE.assertEqual("some-conceptual-dataset", conceptual_dataset.label)
+        TEST_CASE.assertEqual("some-conceptual-dataset", conceptual_dataset.description)
 
-    def test_import_instruments(
-        self, study_import_manager, study, period, elasticsearch_indices, analysis_unit
-    ):
-        assert 0 == Instrument.objects.count()
-        assert 0 == Question.objects.count()
-        study_import_manager.import_single_entity("instruments")
-        assert 1 == Instrument.objects.count()
-        assert 1 == Question.objects.count()
+    @pytest.mark.usefixtures(("elasticsearch_indices"))
+    def test_import_instruments(self, study, period, analysis_unit):
+        TEST_CASE.assertEqual(0, Instrument.objects.count())
+        TEST_CASE.assertEqual(0, Question.objects.count())
+        with TEST_CASE.assertRaises(SystemExit) as _error:
+            call_command("update", study.name, "instruments", "-l")
+            TEST_CASE.assertEqual(0, _error.exception.code)
+        TEST_CASE.assertEqual(1, Instrument.objects.count())
+        TEST_CASE.assertEqual(1, Question.objects.count())
         instrument = Instrument.objects.first()
-        assert "some-instrument" == instrument.name
-        assert study == instrument.study
-        assert analysis_unit == instrument.analysis_unit
-        assert period == instrument.period
+        TEST_CASE.assertEqual("some-instrument", instrument.name)
+        TEST_CASE.assertEqual(study, instrument.study)
+        TEST_CASE.assertEqual(analysis_unit, instrument.analysis_unit)
+        TEST_CASE.assertEqual(period, instrument.period)
 
         search = QuestionDocument.search().query("match_all")
-        assert 1 == search.count()
+        TEST_CASE.assertEqual(1, search.count())
         response = search.execute()
         hit = response.hits[0]
-        # assert study.name == hit.study
-        assert "some-question" == hit.name
-        assert "some-instrument" == hit.instrument
+        # TEST_CASE.assertEqual(study.name, hit.study)
+        TEST_CASE.assertEqual("some-question", hit.name)
+        TEST_CASE.assertEqual("Some Instrument", hit.instrument)
         QuestionDocument.search().query("match_all").delete()
 
-    def test_import_json_datasets(
-        self, study_import_manager, elasticsearch_indices, study
-    ):
-        assert 0 == Dataset.objects.count()
-        assert 0 == Variable.objects.count()
-        study_import_manager.import_single_entity("datasets.json")
-        assert 1 == Dataset.objects.count()
-        assert 2 == Variable.objects.count()
+    @pytest.mark.usefixtures(("elasticsearch_indices"))
+    def test_import_json_datasets(self, study):
+        VariableDocument.search().query("match_all").delete()
+        TEST_CASE.assertEqual(0, Dataset.objects.count())
+        TEST_CASE.assertEqual(0, Variable.objects.count())
+        with TEST_CASE.assertRaises(SystemExit) as _error:
+            call_command("update", study.name, "datasets.json", "-l")
+            TEST_CASE.assertEqual(0, _error.exception.code)
+        TEST_CASE.assertEqual(1, Dataset.objects.count())
+        TEST_CASE.assertEqual(2, Variable.objects.count())
         dataset = Dataset.objects.first()
 
         name = "some-variable"
         variable, created = Variable.objects.get_or_create(name=name)
-        assert "some-dataset" == dataset.name
-        assert study == dataset.study
+        TEST_CASE.assertEqual("some-dataset", dataset.name)
+        TEST_CASE.assertEqual(study, dataset.study)
 
-        assert not created
-        assert name == variable.name
+        TEST_CASE.assertFalse(created)
+        TEST_CASE.assertEqual(name, variable.name)
 
         search = VariableDocument.search().query("match_all")
-        assert 2 == search.count()
+        TEST_CASE.assertEqual(2, len(search.execute()))
         VariableDocument.search().query("match_all").delete()
 
     def test_import_csv_datasets(
-        self, study_import_manager, dataset, period, analysis_unit, conceptual_dataset
+        self, dataset, period, analysis_unit, conceptual_dataset
     ):
-        study_import_manager.import_single_entity("datasets.csv")
-        assert 1 == Dataset.objects.count()
+        with TEST_CASE.assertRaises(SystemExit) as _error:
+            call_command("update", dataset.study.name, "datasets.csv", "-l")
+            TEST_CASE.assertEqual(0, _error.exception.code)
+        TEST_CASE.assertEqual(1, Dataset.objects.count())
         dataset = Dataset.objects.first()
-        assert "some-dataset" == dataset.label
-        assert "some-dataset" == dataset.description
-        assert analysis_unit == dataset.analysis_unit
-        assert period == dataset.period
-        assert conceptual_dataset == dataset.conceptual_dataset
+        TEST_CASE.assertEqual("some-dataset", dataset.label)
+        TEST_CASE.assertEqual("some-dataset", dataset.description)
+        TEST_CASE.assertEqual(analysis_unit, dataset.analysis_unit)
+        TEST_CASE.assertEqual(period, dataset.period)
+        TEST_CASE.assertEqual(conceptual_dataset, dataset.conceptual_dataset)
 
-    def test_import_variables(self, study_import_manager, variable, concept):
-        assert 1 == Variable.objects.count()
-        study_import_manager.import_single_entity("variables")
-        assert 2 == Variable.objects.count()
+    def test_import_variables(self, study, variable, concept):
+        TEST_CASE.assertEqual(1, Variable.objects.count())
+        with TEST_CASE.assertRaises(SystemExit) as _exit:
+            call_command("update", study.name, "concepts", "-l")
+            TEST_CASE.assertEqual(0, _exit.exception.code)
+        with TEST_CASE.assertRaises(SystemExit) as _exit:
+            call_command("update", study.name, "variables", "-l")
+            TEST_CASE.assertEqual(0, _exit.exception.code)
+        TEST_CASE.assertEqual(3, Variable.objects.count())
         imported_variable = Variable.objects.get(
             name=variable.name, dataset=variable.dataset
         )
-        assert "https://variable-image.de" == imported_variable.image_url
-        assert concept == imported_variable.concept
+        TEST_CASE.assertEqual("https://variable-image.de", imported_variable.image_url)
+        TEST_CASE.assertEqual(concept, imported_variable.concept)
 
     def test_import_questions_variables(self, study_import_manager, variable, question):
-        assert 0 == QuestionVariable.objects.count()
+        TEST_CASE.assertEqual(0, QuestionVariable.objects.count())
         study_import_manager.import_single_entity("questions_variables")
-        assert 1 == QuestionVariable.objects.count()
+        TEST_CASE.assertEqual(1, QuestionVariable.objects.count())
         relation = QuestionVariable.objects.first()
-        assert variable == relation.variable
-        assert question == relation.question
+        TEST_CASE.assertEqual(variable, relation.variable)
+        TEST_CASE.assertEqual(question, relation.question)
 
     def test_import_concepts_questions(self, study_import_manager, concept, question):
-        assert 0 == ConceptQuestion.objects.count()
+        TEST_CASE.assertEqual(0, ConceptQuestion.objects.count())
         study_import_manager.import_single_entity("concepts_questions")
-        assert 1 == ConceptQuestion.objects.count()
+        TEST_CASE.assertEqual(1, ConceptQuestion.objects.count())
         relation = ConceptQuestion.objects.first()
-        assert concept == relation.concept
-        assert question == relation.question
+        TEST_CASE.assertEqual(concept, relation.concept)
+        TEST_CASE.assertEqual(question, relation.question)
 
     def test_import_transformations(self, study_import_manager, variable):
-        assert 0 == Transformation.objects.count()
+        TEST_CASE.assertEqual(0, Transformation.objects.count())
         other_variable = VariableFactory(name="some-other-variable")
         study_import_manager.import_single_entity("transformations")
-        assert 1 == Transformation.objects.count()
+        TEST_CASE.assertEqual(1, Transformation.objects.count())
         relation = Transformation.objects.first()
-        assert variable == relation.origin
-        assert other_variable == relation.target
+        TEST_CASE.assertEqual(variable, relation.origin)
+        TEST_CASE.assertEqual(other_variable, relation.target)
 
     def test_import_attachments(self, study_import_manager, study):
-        assert 0 == Attachment.objects.count()
+        TEST_CASE.assertEqual(0, Attachment.objects.count())
         study_import_manager.import_single_entity("attachments")
-        assert 1 == Attachment.objects.count()
+        TEST_CASE.assertEqual(1, Attachment.objects.count())
         attachment = Attachment.objects.first()
-        assert study == attachment.context_study
-        assert "https://some-study.de" == attachment.url
-        assert "some-study" == attachment.url_text
+        TEST_CASE.assertEqual(study, attachment.context_study)
+        TEST_CASE.assertEqual("https://some-study.de", attachment.url)
+        TEST_CASE.assertEqual("some-study", attachment.url_text)
 
-    def test_import_publications(
-        self, study_import_manager, elasticsearch_indices, study
-    ):
-        assert 0 == Publication.objects.count()
+    @pytest.mark.usefixtures(("elasticsearch_indices"))
+    def test_import_publications(self, study_import_manager, study):
+        TEST_CASE.assertEqual(0, Publication.objects.count())
         study_import_manager.import_single_entity("publications")
 
-        assert 1 == Publication.objects.count()
+        TEST_CASE.assertEqual(1, Publication.objects.count())
         publication = Publication.objects.first()
-        assert "Some Publication" == publication.title
-        assert "some-doi" == publication.doi
-        assert study == publication.study
+        TEST_CASE.assertEqual("Some Publication", publication.title)
+        TEST_CASE.assertEqual("some-doi", publication.doi)
+        TEST_CASE.assertEqual(study, publication.study)
         search = PublicationDocument.search().query("match_all")
-        assert 1 == search.count()
+        TEST_CASE.assertEqual(1, search.count())
         response = search.execute()
         hit = response.hits[0]
-        assert study.title() == hit.study
-        assert "some-doi" == hit.doi
-        assert 2018 == hit.year
+        TEST_CASE.assertEqual(study.title(), hit.study)
+        TEST_CASE.assertEqual("some-doi", hit.doi)
+        TEST_CASE.assertEqual(2018, hit.year)
         PublicationDocument.search().query("match_all").delete()
 
-    def test_import_all(self, study_import_manager, elasticsearch_indices):
-        assert 1 == Study.objects.count()
+    @pytest.mark.usefixtures(("elasticsearch_indices"))
+    def test_import_all(self, study):
+        TEST_CASE.assertEqual(1, Study.objects.count())
 
-        assert 0 == Concept.objects.count()
-        assert 0 == ConceptualDataset.objects.count()
-        assert 0 == Dataset.objects.count()
-        assert 0 == Variable.objects.count()
-        assert 0 == Period.objects.count()
-        assert 0 == Publication.objects.count()
-        assert 0 == Question.objects.count()
-        assert 0 == Transformation.objects.count()
-        assert 0 == Instrument.objects.count()
-        assert 0 == QuestionVariable.objects.count()
-        assert 0 == ConceptQuestion.objects.count()
+        TEST_CASE.assertEqual(0, Concept.objects.count())
+        TEST_CASE.assertEqual(0, ConceptualDataset.objects.count())
+        TEST_CASE.assertEqual(0, Dataset.objects.count())
+        TEST_CASE.assertEqual(0, Variable.objects.count())
+        TEST_CASE.assertEqual(0, Period.objects.count())
+        TEST_CASE.assertEqual(0, Publication.objects.count())
+        TEST_CASE.assertEqual(0, Question.objects.count())
+        TEST_CASE.assertEqual(0, Transformation.objects.count())
+        TEST_CASE.assertEqual(0, Instrument.objects.count())
+        TEST_CASE.assertEqual(0, QuestionVariable.objects.count())
+        TEST_CASE.assertEqual(0, ConceptQuestion.objects.count())
 
-        study_import_manager.import_all_entities()
-        assert 1 == Concept.objects.count()
-        assert 1 == ConceptualDataset.objects.count()
-        assert 1 == Dataset.objects.count()
-        assert 2 == Variable.objects.count()
-        assert 1 == Period.objects.count()
-        assert 1 == Publication.objects.count()
-        assert 1 == Question.objects.count()
-        assert 1 == Transformation.objects.count()
-        assert 1 == Instrument.objects.count()
-        assert 1 == QuestionVariable.objects.count()
-        assert 1 == ConceptQuestion.objects.count()
+        with TEST_CASE.assertRaises(SystemExit) as _error:
+            call_command("update", study.name, "-l")
+            TEST_CASE.assertEqual(0, _error.exception.code)
+        TEST_CASE.assertEqual(2, Concept.objects.count())
+        TEST_CASE.assertEqual(1, ConceptualDataset.objects.count())
+        TEST_CASE.assertEqual(1, Dataset.objects.count())
+        TEST_CASE.assertEqual(3, Variable.objects.count())
+        TEST_CASE.assertEqual(1, Period.objects.count())
+        TEST_CASE.assertEqual(1, Publication.objects.count())
+        TEST_CASE.assertEqual(1, Question.objects.count())
+        TEST_CASE.assertEqual(1, Transformation.objects.count())
+        TEST_CASE.assertEqual(1, Instrument.objects.count())
+        TEST_CASE.assertEqual(1, QuestionVariable.objects.count())
+        TEST_CASE.assertEqual(1, ConceptQuestion.objects.count())
 
-        assert ConceptDocument.search().query("match_all").count() == 1
-        assert VariableDocument.search().query("match_all").count() == 2
-        assert PublicationDocument.search().query("match_all").count() == 1
-        assert QuestionDocument.search().query("match_all").count() == 1
+        concept_search = ConceptDocument.search().query("match_all").execute()
+        variable_search = VariableDocument.search().query("match_all").execute()
+        publication_search = PublicationDocument.search().query("match_all").execute()
+        question_search = QuestionDocument.search().query("match_all").execute()
+
+        TEST_CASE.assertEqual(2, len(concept_search))
+        TEST_CASE.assertEqual(3, len(variable_search))
+        TEST_CASE.assertEqual(1, len(publication_search))
+        TEST_CASE.assertEqual(1, len(question_search))
 
         ConceptDocument.search().query("match_all").delete()
         VariableDocument.search().query("match_all").delete()

--- a/tests/functional/test_data/some-study/ddionrails/variables.csv
+++ b/tests/functional/test_data/some-study/ddionrails/variables.csv
@@ -1,3 +1,4 @@
-study_name,dataset_name,variable_name,concept_name,image_url
+study_name,dataset_name,name,concept_name,image_url
 some-study,some-dataset,some-variable,some-concept,https://variable-image.de
 some-study,some-dataset,some-other-variable,some-concept,https://variable-other-image.de
+some-study,some-dataset,some-third-variable,orphaned-concept,https://variable-other-image.de


### PR DESCRIPTION
* Migrate concepts only present in the variable.csv to the concepts.csv
  before executing imports.
* Refactor import tests to use real test files.