### PR TITLE
Add install and setup of js libs to entrypoint

### DIFF
--- a/docker/ddionrails/entrypoint.sh
+++ b/docker/ddionrails/entrypoint.sh
@@ -13,6 +13,12 @@ python manage.py rqworker &
 echo "Creating search indices"
 python manage.py search_index --create || echo "Creating search indices failed." &
 
+apk add --no-cache npm & \
+npm install & \
+npm run build & \
+rm -r node_modules & \
+apk del npm &&
+
 echo "Starting server"
 exec "$@"
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack-cli": "^3.3.11"
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "find ./static/dist/ \\( -name \"*.js\" -o -name \"*.js.map\" -o -name \"*.css\" \\) -exec rm {} + & webpack --config webpack.config.js",
     "build_dev": "webpack --mode=development --config webpack.config.js --debug --devtool source-map",
     "webpack_watch": "webpack --mode=development --config webpack.config.js --watch --debug --devtool source-map",
     "lint": "eslint",


### PR DESCRIPTION
In production a volume is shared between nginx and web container
to enable nginx to serve the JavaScript files.
This overwrites the JavaScript modules created at image build time.
At container start these modules are now rebuild in the background.

The `npm run build` script was modified to delete JavaScript and css
files before recreating them with webpack.
This is done to prevent the accumulation of files, no longer used.