### PR TITLE
Change `Search in Study` link to be absolute

### DIFF
--- a/templates/nav/study.html
+++ b/templates/nav/study.html
@@ -13,7 +13,12 @@
         {% endif %}
         <li class="nav-item"><a href="{% url 'publ:study_publication_list' study_name=study.name %}" class="nav-link">Publications</a>
         </li>
-        <li class="nav-item"><a href='search/all?Study="{{ study.label }}"' class="nav-link">Search in Study</a>
+        <li class="nav-item">
+        <a
+            href='{{ request.scheme }}://{{ request.get_host }}/search/all?Study="{{ study.label }}"'
+            class="nav-link">
+            Search in Study
+        </a>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
Close #1296

* `Search in Study` Navigational link was relative to
a studies main page and worked only from there.

* Link is now created as absolute path
with the hosts name and the used HTTP scheme.