### PR TITLE
Fix import failure when concepts.csv is missing

### DIFF
--- a/ddionrails/imports/manager.py
+++ b/ddionrails/imports/manager.py
@@ -188,7 +188,9 @@ class StudyImportManager:
         """Add missing concepts, only present in the variable.csv, to the concepts.csv"""
         if self._concepts_fixed:
             return None
-        concept_path = self.import_order["concepts"][1]
+        concept_path = Path(self.import_order["concepts"][1])
+        if not concept_path.exists():
+            return None
         variable_path = self.import_order["variables"][1]
         with open(variable_path, "r") as variable_csv:
             variable_concepts = {

--- a/tests/data/test_imports.py
+++ b/tests/data/test_imports.py
@@ -3,6 +3,7 @@
 """ Test cases for importer classes in ddionrails.data app """
 
 import csv
+import os
 import unittest
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -332,6 +333,20 @@ class TestVariableImport:
         result = Variable.objects.filter(name__in=list(variable_names))
         TEST_CASE.assertNotEqual(0, len(result))
         TEST_CASE.assertEqual(len(variable_names), len(result))
+
+    def test_variable_import_without_concept_csv(self):
+
+        csv_path = Study().import_path()
+        concept_path = csv_path.joinpath("concepts.csv")
+
+        os.remove(concept_path)
+
+        some_dataset = DatasetFactory(name="some-dataset")
+        some_dataset.save()
+        TEST_CASE.assertIsNone(
+            StudyImportManager(study=some_dataset.study).fix_concepts_csv()
+        )
+        TEST_CASE.assertFalse(concept_path.exists())
 
     def test_import_element_method(self, mocker, variable_importer, dataset):
         mocked_import_variable = mocker.patch.object(VariableImport, "_import_variable")


### PR DESCRIPTION
Method to fix concepts.csv broke the import when
concepts.csv was not present.