### PR TITLE
quickfix for long datasets, see #1287

### DIFF
--- a/ddionrails/workspace/mixins.py
+++ b/ddionrails/workspace/mixins.py
@@ -28,6 +28,18 @@ class SoepMixin:
         """
         Returns dict with dataset information
         """
+        if dataset_name not in SoepDatasets().data.keys():
+            return dict(
+                name = dataset_name,
+                analysis_unit = "",
+                period = "",
+                prefix = "",
+                is_matchable = "",
+                is_special = "",
+                curr_hid = "",
+                variables = set(),
+            )
+
         dataset = SoepDatasets().get_dict(dataset_name)
         return dict(
             name = dataset_name,


### PR DESCRIPTION
Every dataset gets an entry.
If its not in the json file, it remains empty.

Close: #1287


