### PR TITLE
Fix 500 error in script generation

### DIFF
--- a/ddionrails/workspace/mixins.py
+++ b/ddionrails/workspace/mixins.py
@@ -24,18 +24,22 @@ class SoepMixin:
 
     @staticmethod
     def _create_dataset_dict(dataset_name: str) -> Dict:
-        """
-        Returns dict with dataset information
+        """ Returns dict with dataset information
+
+        A possible empty dict from SoepDatasets().get_dict()
+        Is handled with "" as default values.
+        Variables from such a dataset will be included in the
+        `NOT PROCESSED` section of the created script.
         """
         dataset = SoepDatasets().get_dict(dataset_name)
         return dict(
             name=dataset_name,
-            analysis_unit=dataset["analyse_unit"],
-            period=dataset["syear"],
-            prefix=dataset["prefix"],
-            is_matchable=dataset["is_matchable"],
-            is_special=dataset["is_special"],
-            curr_hid=dataset["curr_hid"],
+            analysis_unit=dataset.get("analyse_unit", ""),
+            period=dataset.get("syear", ""),
+            prefix=dataset.get("prefix", ""),
+            is_matchable=dataset.get("is_matchable", ""),
+            is_special=dataset.get("is_special", ""),
+            curr_hid=dataset.get("curr_hid", ""),
             variables=set(),
         )
 

--- a/ddionrails/workspace/mixins.py
+++ b/ddionrails/workspace/mixins.py
@@ -11,9 +11,7 @@ class SoepMixin:
     """SoepMixin - utilities/helpers to get SOEP years and year prefixes"""
 
     def _generate_script_dict(self):
-        """
-        Creates a dictionary with dataset names as keys and variables from basket as values
-        """
+        """ Map variables from basket to their dataset names """
         script_dict = dict()
         for variable in self.basket.variables.all():
             dataset_name = variable.dataset.name
@@ -24,20 +22,21 @@ class SoepMixin:
                 self._enrich_dataset_dict(dataset_dict)
         return script_dict
 
-    def _create_dataset_dict(self, dataset_name: str) -> Dict:
+    @staticmethod
+    def _create_dataset_dict(dataset_name: str) -> Dict:
         """
         Returns dict with dataset information
         """
         dataset = SoepDatasets().get_dict(dataset_name)
         return dict(
-            name = dataset_name,
-            analysis_unit = dataset["analyse_unit"],
-            period = dataset["syear"],
-            prefix = dataset["prefix"],
-            is_matchable = dataset["is_matchable"],
-            is_special = dataset["is_special"],
-            curr_hid = dataset["curr_hid"],
-            variables = set(),
+            name=dataset_name,
+            analysis_unit=dataset["analyse_unit"],
+            period=dataset["syear"],
+            prefix=dataset["prefix"],
+            is_matchable=dataset["is_matchable"],
+            is_special=dataset["is_special"],
+            curr_hid=dataset["curr_hid"],
+            variables=set(),
         )
 
     @staticmethod
@@ -46,18 +45,17 @@ class SoepMixin:
         Set merge_id variables and add variables to dataset
         """
 
-        d = dataset_dict
-        analysis_unit = d["analysis_unit"]
+        analysis_unit = dataset_dict["analysis_unit"]
         if analysis_unit == "h":
-            d["merge_id"] = d["curr_hid"]
-            d["variables"].add(d["curr_hid"])
+            dataset_dict["merge_id"] = dataset_dict["curr_hid"]
+            dataset_dict["variables"].add(dataset_dict["curr_hid"])
         elif analysis_unit == "p":
-            d["merge_id"] = "persnr"
-            d["variables"].add("persnr")
-            if d["curr_hid"] != "":
-                d["variables"].add(d["curr_hid"])
+            dataset_dict["merge_id"] = "persnr"
+            dataset_dict["variables"].add("persnr")
+            if dataset_dict["curr_hid"] != "":
+                dataset_dict["variables"].add(dataset_dict["curr_hid"])
         else:
-            d["merge_id"] = ""
+            dataset_dict["merge_id"] = ""
 
     @staticmethod
     def _validate_datasets(script_dict, analysis_unit, valid=True):
@@ -84,7 +82,10 @@ class SoepMixin:
         for dataset_name in script_dict.keys():
             if dataset_name in all_datasets:
                 if script_dict[dataset_name]["prefix"] != "":
-                    if analysis_unit == "h" and script_dict[dataset_name]["analysis_unit"] == "p":
+                    if (
+                        analysis_unit == "h"
+                        and script_dict[dataset_name]["analysis_unit"] == "p"
+                    ):
                         invalid_list.append(dataset_name)
                     else:
                         valid_list.append(dataset_name)
@@ -99,6 +100,4 @@ class SoepMixin:
 
         if valid:
             return valid_list
-        else:
-            return invalid_list
-
+        return invalid_list

--- a/ddionrails/workspace/scripts/soep_datasets.py
+++ b/ddionrails/workspace/scripts/soep_datasets.py
@@ -19,6 +19,7 @@ TODO: Add checks and exceptions ..
 
 import json
 from os import path
+from typing import Dict, Union
 
 ############################################################
 # File   : soep_datasets.py
@@ -79,8 +80,14 @@ class SoepDatasets:
     def __init__(self, json_file=_default_json_datasets_file):
         self.data = SoepDatasetsJsonLoader().load_json_data(json_file)
 
-    def get_dict(self, dataset_name):
-        return self.data[dataset_name]
+    def get_dict(self, dataset_name) -> Union[Dict[str, str], Dict]:
+        """ Return dataset information
+
+        Returns:
+            The dataset information from the datafiles.json file
+            or an empty dictionairy if dataset_name is not present in JSON file.
+        """
+        return self.data.get(dataset_name, dict())
 
     def get_dataset(self, dataset_name):
         dataset_property = self.get_dict(dataset_name)

--- a/ddionrails/workspace/scripts/soep_datasets.py
+++ b/ddionrails/workspace/scripts/soep_datasets.py
@@ -1,10 +1,4 @@
 #!/usr/bin/python3
-
-############################################################
-# File   : soep_datasets.py
-# Date   : 2020-02-04 / ISO 8601: YYYY-MM-DD
-# Author : mpahl
-############################################################
 """
 Example:
 # from soep_datasets import SoepDatasets
@@ -23,13 +17,21 @@ TODO: Add checks and exceptions ..
 
 """
 
-############################################################
-# imports
-
 import json
 from os import path
 
 ############################################################
+# File   : soep_datasets.py
+# Date   : 2020-02-04 / ISO 8601: YYYY-MM-DD
+# Author : mpahl
+############################################################
+
+############################################################
+# imports
+
+
+############################################################
+
 
 class SoepDatasetsJsonLoader:
     """class SoepDatasetsJsonLoader -
@@ -44,21 +46,24 @@ class SoepDatasetsJsonLoader:
         _json_data = {}
 
         if path.exists(json_file):
-            with open(json_file) as f:
-                _json_data = json.load(f)
+            with open(json_file) as file:
+                _json_data = json.load(file)
 
         return _json_data
+
 
 class SoepDataset:
     """
     TODO: Describe this module and methodes ..
     """
+
     def __init__(self):
         self.sub_path = ""
         self.syear = ""
         self.prefix = ""
         self.analyse_unit = ""
         self.is_matchable = ""
+
 
 class SoepDatasets:
     """
@@ -67,7 +72,7 @@ class SoepDatasets:
 
     # Default path to json file
     # _default_json_datasets_file = "../datafiles.json" # bash tests
-    _default_json_datasets_file = "ddionrails/workspace/datafiles.json" # local tests
+    _default_json_datasets_file = "ddionrails/workspace/datafiles.json"  # local tests
     # _default_json_datasets_file = "ddionrails/workspace/datafiles_with_long.json"
 
     ########################################################
@@ -89,6 +94,7 @@ class SoepDatasets:
         _dataset.is_matchable = dataset_property["_is_matchable"]
 
         return _dataset
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
When initiating a script generator,
workspace.scripts.soep_datasets.SoepDatasets.get_dict() is called.
The SoepDatasets class is initiated with the content of a json file:
ddionrails/workspace/datafiles.json

If a variable inside a basket does not belong to a dataset
in this json file, a KeyError will be raise at
ddionrails.workspace.scripts.soep_datasets.SoepDatasets.get_dict()
This causes the user to receive a 500 internal error.

* get_dict now returns an empty dict for these datasets
* ddionrails.workspace.mixins.SoepMixin._create_dataset_dict()
  handles the the empty dict by defaulting to "" as default values.

* The empty values will exclude variables from being processed and
  add the to the `NOT PROCESSED` section of the script.

Close #1287