### PR TITLE
Move js files instead if cp them in entrypoint

### DIFF
--- a/docker/ddionrails/entrypoint.sh
+++ b/docker/ddionrails/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Collect Admin stiling etc.
-cp -r ${WEB_LIBRARY}/* ${WEB_LIBRARY_SERV_DIR}/
+mv ${WEB_LIBRARY}/* ${WEB_LIBRARY_SERV_DIR}/
 python manage.py collectstatic --noinput
 
 echo "Initialising System"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack-cli": "^4.0.0"
   },
   "scripts": {
-    "build": "find ./static/dist/ \\( -name \"*.js\" -o -name \"*.js.map\" -o -name \"*.css\" \\) -exec rm {} + & webpack --config webpack.config.js",
+    "build": "webpack --config webpack.config.js",
     "build_dev": "webpack --mode=development --config webpack.config.js --devtool source-map",
     "webpack_watch": "webpack --mode=development --config webpack.config.js --watch --devtool source-map",
     "lint": "eslint",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
   output: {
     path: path.resolve("./static/dist/"),
     publicPath: "",
-    filename: "[name]-[contenthash].js",
+    filename: "[name].js",
   },
 
   plugins: [


### PR DESCRIPTION
This should minimize the amount of files moved on container startup.
Move will only move the files during first startup, since them being moved
will persist through the containers lifetime.