### PR TITLE
fix: Change study in TopicResult.vue

### DIFF
--- a/assets/js/search/components/results/TopicResult.vue
+++ b/assets/js/search/components/results/TopicResult.vue
@@ -8,7 +8,12 @@
         <span v-html="item.label"></span>
       </a>
     </p>
-    <p class="card-text">Topic in study {{ item.study }}</p>
+    <p class="card-text">Topic in study:
+      <a
+        :href="'/' + item.study.name"
+        v-html="item.study.label">
+      </a>
+    </p>
   </div>
 </template>
 


### PR DESCRIPTION
## Proposed changes

I just saw that in a topic search, you output the whole topic document dict, see e.g. https://paneldata.org/search/topics?Study=%5B%22SOEP-Core%22%5D

This is a quick fix, feel free to adapt. I just wanted to drop a PR. :smiley: 
I used the :href directive (?) like in `VariableResult.vue.`
