### PR TITLE
chore: add github-actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,14 @@ updates:
     labels:
       - "PostfixDockerImage"
       - "dependencies"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: "04:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 10
+    target-branch: develop
+    labels:
+      - github-actions
+      - dependencies


### PR DESCRIPTION
## Proposed changes

Hi @hansendx, I learned a lot recently about GitHub actions. I realized that your repository uses an older version of the codecov action (its now at 3.11). You can let Dependabot send you updates for GitHub actions as well: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- no code affected, did not run pytest at all