### PR TITLE
chore: pin github actions in CI

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Before install
         run: |
@@ -64,7 +64,7 @@ jobs:
           docker exec ddionrails_web_1 mv coverage.xml codecov/
       - name: Upload codecov report
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./codecov/coverage.xml


### PR DESCRIPTION
## Proposed changes
- pin GitHub actions in CI
- dependabot will be able to parse this syntax and update accordingly
- feel free to accept or close this PR

Reference: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist
- did not run pytest locally, no Python code affected by this PR
