### PR TITLE
[WIP] chore: add lint job in CI

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -12,8 +12,22 @@ env:
   COMPOSE_FILE: docker-compose.yml:docker-compose-ci.yml
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # https://github.com/actions/setup-python
+      - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
+        with:
+          python-version: "3.11"
+          cache: "pipenv"
+      - run: pipx install pipenv
+      - run: pipenv install --dev
+      - run: pipenv run pre-commit run --all-files
+
   tests:
     runs-on: ubuntu-latest
+    needs: [lint]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -21,7 +21,10 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pipenv"
-      - run: pip install pipenv
+      # TODO: this is required by pygraphviz in the Pipfile dev requirements
+      # TODO: a switch to poetry would enable dependency groups, like local, ci etc.
+      - run: sudo apt-get install -y graphviz graphviz-dev
+      - run: pipx install pipenv
       - run: pipenv install --dev
       - run: pipenv run pre-commit run --all-files
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pipenv"
-      - run: pipx install pipenv
+      - run: pip install pipenv
       - run: pipenv install --dev
       - run: pipenv run pre-commit run --all-files
 


### PR DESCRIPTION
## Proposed changes

This additional CI job might help with contributors not using pre-commit locally. The lint job could run and potentially fail early, before building the docker containers. Running "pre-commit" in the docker container is of course also an option. But this might fail faster and safe some compute time.

What do you think, @hansendx?

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- no code affected
