### PR TITLE
build: enable parallel indexing in Elasticsearch

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -257,7 +257,7 @@ ELASTICSEARCH_PASSWORD = os.getenv("ELASTIC_PASSWORD")
 # Prefix for index names.
 # Overwritten in testing settings to separate testings indices which get deleted a lot
 ELASTICSEARCH_DSL_INDEX_PREFIX = os.getenv("ELASTICSEARCH_DSL_INDEX_PREFIX", "")
-# https://github.com/sabricot/django-elasticsearch-dsl#quickstart
+# https://django-elasticsearch-dsl.readthedocs.io/en/latest/quickstart.html
 ELASTICSEARCH_DSL = {
     "default": {
         "hosts": (
@@ -266,7 +266,9 @@ ELASTICSEARCH_DSL = {
         )
     }
 }
-# https://github.com/sabricot/django-elasticsearch-dsl#elasticsearch_dsl_autosync
+# https://django-elasticsearch-dsl.readthedocs.io/en/latest/settings.html#elasticsearch-dsl-autosync
 ELASTICSEARCH_DSL_AUTOSYNC = False
-# https://github.com/sabricot/django-elasticsearch-dsl#elasticsearch_dsl_index_settings
+# https://django-elasticsearch-dsl.readthedocs.io/en/latest/settings.html#elasticsearch-dsl-index-settings
 ELASTICSEARCH_DSL_INDEX_SETTINGS = {"number_of_shards": 1, "number_of_replicas": 0}
+# https://django-elasticsearch-dsl.readthedocs.io/en/latest/settings.html#elasticsearch-dsl-parallel
+ELASTICSEARCH_DSL_PARALLEL = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,7 @@ def elasticsearch_indices():
 
     # Create search indices if they do not exist
     try:
-        call_command("search_index", "--create", force=True)
+        call_command("search_index", "--create", "--no-parallel", force=True)
     except RequestError:
         pass
 
@@ -145,7 +145,7 @@ def elasticsearch_indices():
     yield
 
     # Delete search indices after testing
-    call_command("search_index", "--delete", force=True)
+    call_command("search_index", "--delete", "--no-parallel", force=True)
 
 
 @pytest.fixture()
@@ -306,7 +306,7 @@ def _variable(request: FixtureRequest, db: pytest.fixture):
         label="Some Variable",
         label_de="Eine Variable",
         description="This is some variable",
-        statistics=dict(valid="1", invalid="0"),
+        statistics={"valid": "1", "invalid": "0"},
         categories={
             "frequencies": [1, 0],
             "labels": [
@@ -348,7 +348,7 @@ def concepts_index(elasticsearch_indices, concept):  # pylint: disable=unused-ar
     ConceptDocument.search().query("match_all").delete()
     # saving the concept, will index the concept as well
 
-    call_command("search_index", "--populate", force=True)
+    call_command("search_index", "--populate", "--no-parallel", force=True)
 
     concept.save()
     expected = 1
@@ -541,8 +541,7 @@ class MockOpener:
             _file = self.files[Path(path)]
         except KeyError as error:
             raise ValueError("Path is not registered.") from error
-        else:
-            return bool(_file["mocker"])
+        return bool(_file["mocker"])
 
     @staticmethod
     def _stitch_together_write_output(mocker):

--- a/tests/functional/imports/test_imports.py
+++ b/tests/functional/imports/test_imports.py
@@ -50,7 +50,7 @@ def _study_import_manager(study, settings):
 @pytest.fixture(name="clean_search_index")
 def _clean_search_index():
     yield
-    call_command("search_index", "--delete", force=True)
+    call_command("search_index", "--delete", "--no-parallel", force=True)
 
 
 @pytest.fixture(name="unittest_settings")
@@ -62,7 +62,6 @@ def _unittest_settings(request, settings):
 @pytest.mark.django_db
 @pytest.mark.usefixtures("unittest_settings", "tmp_dir")
 class TestStudyImportManagerUnittest(unittest.TestCase):
-
     data_dir: Path
     settings: Any
     study: Study
@@ -108,7 +107,7 @@ class TestStudyImportManagerUnittest(unittest.TestCase):
             "url",
             "url_text",
         )
-        row = dict(type="dataset", dataset="Nonexistent-dataset")
+        row = {"type": "dataset", "dataset": "Nonexistent-dataset"}
         with open(import_path, "w", encoding="utf8") as attachements_file:
             writer = csv.DictWriter(attachements_file, fieldnames=header)
             writer.writeheader()
@@ -228,7 +227,7 @@ class TestStudyImportManager:
         TEST_CASE.assertEqual(analysis_unit, instrument.analysis_unit)
         TEST_CASE.assertEqual(period, instrument.period)
 
-        call_command("search_index", "--populate")
+        call_command("search_index", "--populate", "--no-parallel")
         search = QuestionDocument.search().query("match_all")
         TEST_CASE.assertEqual(1, search.count())
         response = search.execute()
@@ -357,8 +356,7 @@ class TestStudyImportManager:
 
     @pytest.mark.usefixtures("elasticsearch_indices")
     def test_import_all(self, study):
-
-        call_command("search_index", "--delete", force=True)
+        call_command("search_index", "--delete", "--no-parallel", force=True)
         TEST_CASE.assertEqual(1, Study.objects.count())
 
         TEST_CASE.assertEqual(0, Concept.objects.count())


### PR DESCRIPTION
## Proposed changes

Hi @hansendx, I dug up an abandoned issue. Depending on the frequency of indexing from postgres to elasticsearch, indexing in parallel could speed up the operations.

Related issue: #1004

## Types of changes

- improvement of indexing performance


## Checklist
- Pytest passes locally with my changes

Feel free to test in dev setup and merge or close.