### PR TITLE
chore: replace psycopg2 with psycopg3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,7 +29,7 @@ djangorestframework = ">=3.14.0"
 django_filer = "*"
 # PostgreSQL
 # ------------------------------------------------------------------------------
-psycopg2-binary = "*"
+psycopg = {extras = ["binary"], version = "*"}
 #
 #
 # Elasticsearch


### PR DESCRIPTION
## Proposed changes

I recently read about Django 4 being able to utilize psycopg3 (the pip package is just called psycopg) for postgresql. Dependabot will not mention this because it only looks for newer versions of psycopg2. You need to install psycopg and psycopg-binary (or psycopg[binary]).

What do you think?

## Types of changes

- dependency update/upgrade

## Checklist

I could not lock the Pipfile for some reason. I usually just deleted the old version and ran lock again, but I do not want to do it without permission.

- [ ] update lockfile

## Further comments

- https://docs.djangoproject.com/en/dev/releases/4.2/#psycopg-3-support
- https://www.psycopg.org/psycopg3/docs/news.html
- https://www.psycopg.org/psycopg3/docs/basic/from_pg2.html
