### PR TITLE
Add variable name search

### DIFF
--- a/assets/js/search/app.tsx
+++ b/assets/js/search/app.tsx
@@ -284,7 +284,7 @@ function App() {
             {language === "de" ? "Variablen" : "Variables"}
           </LinkWithQuery>
           <LinkWithQuery to="/variable-names">
-            {language === "de" ? "Variablennamen" : "Variable name search"}
+ <i className="fa-solid fa-terminal"></i> {language === "de" ? "Variablennamen" : "Variable name search"}
           </LinkWithQuery>
           <LinkWithQuery to="/questions">
             {language === "de" ? "Fragen" : "Questions"}

--- a/assets/js/search/app.tsx
+++ b/assets/js/search/app.tsx
@@ -65,6 +65,7 @@ import {
   variableFacets,
   variableSorting,
 } from "./search_configs/variable_search_config";
+import { VariableNames } from "./search_components/variable_name_search"
 import { questionResult } from "./result_customizations/question_result";
 import { variableResult } from "./result_customizations/variable_result";
 
@@ -282,6 +283,9 @@ function App() {
           <LinkWithQuery to="/variables">
             {language === "de" ? "Variablen" : "Variables"}
           </LinkWithQuery>
+          <LinkWithQuery to="/variable-names">
+            {language === "de" ? "Variablennamen" : "Variable name search"}
+          </LinkWithQuery>
           <LinkWithQuery to="/questions">
             {language === "de" ? "Fragen" : "Questions"}
           </LinkWithQuery>
@@ -301,6 +305,10 @@ function App() {
           <Route
             path="/variables"
             element={<Variables language={language} />}
+          />
+          <Route
+            path="/variable-names"
+            element={<VariableNames language={language} />}
           />
           <Route
             path="/questions"

--- a/assets/js/search/app.tsx
+++ b/assets/js/search/app.tsx
@@ -65,7 +65,7 @@ import {
   variableFacets,
   variableSorting,
 } from "./search_configs/variable_search_config";
-import { VariableNames } from "./search_components/variable_name_search"
+import { VariableNames } from "./search_components/variable_name_search";
 import { questionResult } from "./result_customizations/question_result";
 import { variableResult } from "./result_customizations/variable_result";
 
@@ -276,39 +276,41 @@ function App() {
   return (
     <>
       <BrowserRouter basename="/search">
-        <div className="search-menu">
-          <LinkWithQuery to="/all">
-            {language === "de" ? "Alles durchsuchen" : "Search all"}
-          </LinkWithQuery>
-          <LinkWithQuery to="/variables">
-            {language === "de" ? "Variablen" : "Variables"}
-          </LinkWithQuery>
-          <LinkWithQuery to="/variable-names">
- <i className="fa-solid fa-terminal"></i> {language === "de" ? "Variablennamen" : "Variable name search"}
-          </LinkWithQuery>
-          <LinkWithQuery to="/questions">
-            {language === "de" ? "Fragen" : "Questions"}
-          </LinkWithQuery>
-          <LinkWithQuery to="/concepts">
-            {language === "de" ? "Konzepte" : "Concepts"}
-          </LinkWithQuery>
-          <LinkWithQuery to="/topics">
-            {language === "de" ? "Themen" : "Topics"}
-          </LinkWithQuery>
-          <LinkWithQuery to="/publications">
-            {language === "de" ? "Publikationen" : "Publications"}
-          </LinkWithQuery>
+        <div className="full-search-menu">
+          <div className="search-menu">
+            <LinkWithQuery to="/all">
+              {language === "de" ? "Alles durchsuchen" : "Search all"}
+            </LinkWithQuery>
+            <LinkWithQuery to="/variables">
+              {language === "de" ? "Variablen" : "Variables"}
+            </LinkWithQuery>
+            <LinkWithQuery to="/questions">
+              {language === "de" ? "Fragen" : "Questions"}
+            </LinkWithQuery>
+            <LinkWithQuery to="/concepts">
+              {language === "de" ? "Konzepte" : "Concepts"}
+            </LinkWithQuery>
+            <LinkWithQuery to="/topics">
+              {language === "de" ? "Themen" : "Topics"}
+            </LinkWithQuery>
+            <LinkWithQuery to="/publications">
+              {language === "de" ? "Publikationen" : "Publications"}
+            </LinkWithQuery>
+          </div>
+          <div className="search-menu" id="variable-names-navigation">
+            <LinkWithQuery to="/variable-names">
+              <i className="fa-solid fa-terminal"></i>{" "}
+              {language === "de" ? "Variablennamen" : "Variable name search"}
+            </LinkWithQuery>
+          </div>
         </div>
+
         <Routes>
           <Route path="/" element={<All language={language} />} />
           <Route path="/all" element={<All language={language} />} />
           <Route
             path="/variables"
             element={<Variables language={language} />}
-          />
-          <Route
-            path="/variable-names"
-            element={<VariableNames language={language} />}
           />
           <Route
             path="/questions"
@@ -319,6 +321,10 @@ function App() {
           <Route
             path="/publications"
             element={<Publications language={language} />}
+          />
+          <Route
+            path="/variable-names"
+            element={<VariableNames language={language} />}
           />
         </Routes>
       </BrowserRouter>

--- a/assets/js/search/search_components/variable_name_search.tsx
+++ b/assets/js/search/search_components/variable_name_search.tsx
@@ -34,7 +34,7 @@ function TruncatedCheckbox({
   side,
   setResult,
   setStartResult,
-  setEndResult
+  setEndResult,
 }: {
   language: string;
   side: string;
@@ -118,14 +118,14 @@ function SearchBox({
           side="left"
           setResult={setResult}
           setStartResult={setStartResult}
-	  setEndResult={setEndResult}
+          setEndResult={setEndResult}
         />
         <TruncatedCheckbox
           language={language}
           side="right"
           setResult={setResult}
           setStartResult={setStartResult}
-	  setEndResult={setEndResult}
+          setEndResult={setEndResult}
         />
       </div>
     </div>
@@ -188,12 +188,14 @@ function ContentBox({
           >
             <a rel="nofollow">1</a>
           </li>
-          <li className={
-
-                endResult - startResult > PAGE_SIZE
-                  ? "rc-pagination-next"
-                  : "rc-pagination-next rc-pagination-disabled"
-		  } aria-disabled="false">
+          <li
+            className={
+              endResult - startResult > PAGE_SIZE
+                ? "rc-pagination-next"
+                : "rc-pagination-next rc-pagination-disabled"
+            }
+            aria-disabled="false"
+          >
             <button
               type="button"
               aria-label="next page"
@@ -230,7 +232,30 @@ function searchWithEnter(
   }
 }
 
-function RenderResults(searchResults: any, language: string) {
+/**
+ * Using string replace and split because 
+ * its easier to implement than something that uses substring indices.
+ * Not just using just replace to <em>searchTerm</em> to avoid
+ * using dangerouslySetHTML with user input.
+ */
+function emphasize(name: string, searchTerm: string) {
+  const emphasizedName = name.replaceAll(searchTerm, `|${searchTerm}|`);
+  return emphasizedName
+    .split("|")
+    .map((term, index) =>
+      term === searchTerm ? (
+        <em key={index}>{term}</em>
+      ) : (
+        <span key={index}>{term}</span>
+      ),
+    );
+}
+
+function RenderResults(
+  searchResults: any,
+  language: string,
+  searchTerm: string,
+) {
   if (!searchResults?.hits) {
     return [<li key={0} />];
   }
@@ -244,7 +269,7 @@ function RenderResults(searchResults: any, language: string) {
           <h3>
             <i className="fa fa-chart-bar"></i>
             <a href={"/variable/" + metadata.id}>
-              {metadata.name}:{" "}
+              {emphasize(metadata.name, searchTerm)}:{" "}
               <span data-en={metadata.label} data-de={metadata.label_de}>
                 {metadata[currentLabel]}
               </span>
@@ -330,6 +355,6 @@ async function search(
   });
   response.json().then((content: any) => {
     setEndResult(content["hits"]["total"]["value"]);
-    setResult(RenderResults(content, language));
+    setResult(RenderResults(content, language, inputText));
   });
 }

--- a/assets/js/search/search_components/variable_name_search.tsx
+++ b/assets/js/search/search_components/variable_name_search.tsx
@@ -171,6 +171,7 @@ async function search(resultSetter: any, startResult: any) {
   ) as HTMLInputElement;
   const inputText = inputElement.value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   if (inputText.trim() === "") {
+    resultSetter(<></>)
     return;
   }
   const response = await fetch("/elastic/variables/_search", {

--- a/assets/js/search/search_components/variable_name_search.tsx
+++ b/assets/js/search/search_components/variable_name_search.tsx
@@ -312,7 +312,7 @@ async function search(
     body: JSON.stringify({
       from: startResult,
       size: PAGE_SIZE,
-      sort: [{ name: "asc" }],
+      sort: [{ name_keyword: "asc" }],
       query: {
         regexp: {
           name: {

--- a/assets/js/search/search_components/variable_name_search.tsx
+++ b/assets/js/search/search_components/variable_name_search.tsx
@@ -1,0 +1,58 @@
+export function VariableNames({ language }: { language: string }) {
+  return <SearchBox language={language} />;
+}
+
+function SearchBox({ language }: { language: string }) {
+  return (
+    <div className="sui-layout-header">
+      <div className="sui-search-box">
+        <input
+          className="sui-search-box__text-input"
+          id="downshift-2-input"
+          placeholder={language == "en" ? "Search" : "Suche"}
+	  onKeyDown={searchWithEnter}
+        ></input>
+        <input
+          data-transaction-name="search submit"
+          type="submit"
+          className="button sui-search-box__submit"
+          value="Search"
+	  onClick={search}
+        />
+      </div>
+    </div>
+  );
+}
+
+function searchWithEnter(event: React.KeyboardEvent<HTMLInputElement>){
+	if(event.key === "Enter"){
+		search()
+	}
+}
+
+
+function search() {
+  const inputElement = document.getElementById("downshift-2-input") as HTMLInputElement;
+  const inputText = inputElement.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (inputText.trim() === ""){
+	  return
+  }
+  fetch("/elastic/variables/_search", {
+    method: "POST",
+    body: JSON.stringify({
+      query: {
+        regexp: {
+          name: {
+            value: ".*" + inputText,
+            flags: "ALL",
+            case_insensitive: true,
+            max_determinized_states: 10000,
+          },
+        },
+      },
+    }),
+    headers: {
+      "Content-type": "application/json; charset=UTF-8",
+    },
+  });
+}

--- a/assets/js/search/search_components/variable_name_search.tsx
+++ b/assets/js/search/search_components/variable_name_search.tsx
@@ -1,8 +1,22 @@
+import React, { useState } from "react";
+
 export function VariableNames({ language }: { language: string }) {
-  return <SearchBox language={language} />;
+  const [results, setResults] = useState([<li key={1}/>]);
+  return (
+    <div>
+      <SearchBox language={language} resultSetter={setResults} />
+      <ContentBox language={language} results={results} />
+    </div>
+  );
 }
 
-function SearchBox({ language }: { language: string }) {
+function SearchBox({
+  language,
+  resultSetter,
+}: {
+  language: string;
+  resultSetter: any;
+}) {
   return (
     <div className="sui-layout-header">
       <div className="sui-search-box">
@@ -10,36 +24,116 @@ function SearchBox({ language }: { language: string }) {
           className="sui-search-box__text-input"
           id="downshift-2-input"
           placeholder={language == "en" ? "Search" : "Suche"}
-	  onKeyDown={searchWithEnter}
+          onKeyDown={(event) => {
+            searchWithEnter(event, resultSetter);
+          }}
         ></input>
         <input
           data-transaction-name="search submit"
           type="submit"
           className="button sui-search-box__submit"
           value="Search"
-	  onClick={search}
+          onClick={() => {
+            search(resultSetter);
+          }}
         />
       </div>
     </div>
   );
 }
 
-function searchWithEnter(event: React.KeyboardEvent<HTMLInputElement>){
-	if(event.key === "Enter"){
-		search()
-	}
+function ContentBox({ language, results }: { language: string; results: any }) {
+  return (
+    <div className="sui-layout-main">
+      <ul className="sui-results-container" id="results-container">
+        { results }
+      </ul>
+      <div className="sui-layout-main-footer">
+        <ul className="rc-pagination sui-paging hidden">
+          <li
+            className="rc-pagination-prev rc-pagination-disabled"
+            aria-disabled="true"
+          >
+            <button
+              type="button"
+              aria-label="prev page"
+              className="rc-pagination-item-link"
+              disabled={false}
+            ></button>
+          </li>
+          <li
+            title="1"
+            className="rc-pagination-item rc-pagination-item-1 rc-pagination-item-active hidden"
+          >
+            <a rel="nofollow">1</a>
+          </li>
+          <li className="rc-pagination-next" aria-disabled="false">
+            <button
+              type="button"
+              aria-label="next page"
+              className="rc-pagination-item-link"
+            ></button>
+          </li>
+          <li className="rc-pagination-options"></li>
+        </ul>
+      </div>
+    </div>
+  );
 }
 
-
-function search() {
-  const inputElement = document.getElementById("downshift-2-input") as HTMLInputElement;
-  const inputText = inputElement.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  if (inputText.trim() === ""){
-	  return
+function searchWithEnter(
+  event: React.KeyboardEvent<HTMLInputElement>,
+  resultSetter: any,
+) {
+  if (event.key === "Enter") {
+    search(resultSetter);
   }
-  fetch("/elastic/variables/_search", {
+}
+
+function RenderResults(searchResults: any) {
+  const output: Array<any> = [];
+  if (!searchResults?.hits) {
+    return [<li key={0} />];
+  }
+  for (const item of searchResults?.hits?.hits) {
+      const metadata = item._source;
+      output.push(
+        <li className="sui-result" key={metadata.id}>
+          <div className="sui-result__header">
+            <h3>
+              <i className="fa fa-chart-bar"></i>
+              <a href={"/variable/" + metadata.id}>
+                {metadata.name}: {metadata.label}
+              </a>
+            </h3>
+          </div>
+          <div className="sui-result__body">
+            <p>
+              Study: {metadata.study.label} | Dataset: {metadata.dataset.label} | Period:
+              {metadata.period.label}
+            </p>
+          </div>
+        </li>,
+      );
+  }
+
+  return output;
+}
+
+async function search(resultSetter: any) {
+  const inputElement = document.getElementById(
+    "downshift-2-input",
+  ) as HTMLInputElement;
+  const inputText = inputElement.value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  if (inputText.trim() === "") {
+    return;
+  }
+  const response = await fetch("/elastic/variables/_search", {
     method: "POST",
     body: JSON.stringify({
+      from: 0,
+      size: 20,
+      sort: [{ name: "asc" }],
       query: {
         regexp: {
           name: {
@@ -55,4 +149,5 @@ function search() {
       "Content-type": "application/json; charset=UTF-8",
     },
   });
+  response.json().then((content: any) => resultSetter(RenderResults(content)));
 }

--- a/assets/js/search/search_components/variable_name_search.tsx
+++ b/assets/js/search/search_components/variable_name_search.tsx
@@ -36,9 +36,9 @@ function TruncatedCheckbox({
   setStartResult: Dispatch<SetStateAction<number>>;
 }) {
   const [checked, setChecked] = useState(true)
-  const germanSide = side === "left" ? "links" : "rechts";
-  const englishLabel = `Truncate search on the ${side} side`;
-  const germanLabel = `Suche ${germanSide} trunkieren`;
+  const germanSide = side === "left" ? "linken" : "rechten";
+  const englishLabel = `Extend search on the ${side} side`;
+  const germanLabel = `Erweitere Suchwort auf der ${germanSide} Seite`;
   return (
     <div className="truncate-checkbox">
       <input

--- a/assets/js/search/search_components/variable_name_search.tsx
+++ b/assets/js/search/search_components/variable_name_search.tsx
@@ -35,6 +35,7 @@ function TruncatedCheckbox({
   setResult: Dispatch<SetStateAction<Array<ReactNode>>>;
   setStartResult: Dispatch<SetStateAction<number>>;
 }) {
+  const [checked, setChecked] = useState(true)
   const germanSide = side === "left" ? "links" : "rechts";
   const englishLabel = `Truncate search on the ${side} side`;
   const germanLabel = `Suche ${germanSide} trunkieren`;
@@ -44,6 +45,8 @@ function TruncatedCheckbox({
         id={"truncate-checkbox-" + side}
         type="checkbox"
         className="sui-multi-checkbox-facet__checkbox"
+	checked={checked}
+	onClick={() => {setChecked(!checked)}}
         onChange={() => {
           setStartResult(PAGE_START);
           search(setResult, PAGE_START, language);

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -137,3 +137,16 @@ div.sui-select__placeholder {
   visibility: visible;
   opacity: 1;
 }
+
+/* Variable-name search */
+
+#truncate-checkbox-container{
+  display: flex;
+  flex-direction: row;
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.truncate-checkbox{
+  margin-right: 1em;
+}

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -138,6 +138,16 @@ div.sui-select__placeholder {
   opacity: 1;
 }
 
+/* Navigation */
+
+.full-search-menu{
+  display: flex;
+}
+
+#variable-names-navigation{
+  margin-left: 1rem;
+}
+
 /* Variable-name search */
 
 #truncate-checkbox-container{

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -150,3 +150,18 @@ div.sui-select__placeholder {
 .truncate-checkbox{
   margin-right: 1em;
 }
+
+#search-explanation {
+    width: 40%;
+    text-align: center;
+    border: solid grey;
+    border-radius: 1rem 1rem 1rem 1rem;
+    padding: 1rem;
+    font-size: 1.3rem;
+}
+
+#search-explanation-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-""" Root URLConf for ddionrails project """
+"""Root URLConf for ddionrails project"""
 
 from django.conf import settings
 from django.conf.urls.static import static
@@ -72,7 +72,7 @@ urlpatterns = [
     re_path(
         (
             r"^search/"
-            r"((?!all|variables|concepts|questions|publications|topics|statistics)"
+            r"((?!all|variables|variable-names|concepts|questions|publications|topics|statistics)"
             r"\?{0,1}.*)$"
         ),
         RedirectView.as_view(url="all/"),
@@ -81,7 +81,7 @@ urlpatterns = [
     re_path(
         (
             r"^search/"
-            r"((?:all|variables|concepts|questions|publications|topics|statistics)"
+            r"((?:all|variables|variable-names|concepts|questions|publications|topics|statistics)"
             r"\?{0,1}.*){0,1}$"
         ),
         TemplateView.as_view(template_name="search/search.html"),

--- a/ddionrails/data/documents.py
+++ b/ddionrails/data/documents.py
@@ -35,7 +35,8 @@ from .models import Variable
 class VariableDocument(GenericDataDocument):
     """Search document data.Variable"""
 
-    name = fields.KeywordField()
+    name = fields.TextField()
+    name_keyword = fields.KeywordField()
 
     dataset = fields.ObjectField(
         properties={
@@ -56,6 +57,12 @@ class VariableDocument(GenericDataDocument):
             "label_de": fields.KeywordField(),
         }
     )
+
+    @staticmethod
+    def prepare_name_keyword(  # pylint: disable=missing-docstring
+        variable: Variable,
+    ) -> Dict[str, str]:
+        return variable.name
 
     @staticmethod
     def _get_study(model_object: Variable) -> Study:

--- a/ddionrails/data/documents.py
+++ b/ddionrails/data/documents.py
@@ -35,7 +35,7 @@ from .models import Variable
 class VariableDocument(GenericDataDocument):
     """Search document data.Variable"""
 
-    name = fields.TextField()
+    name = fields.KeywordField()
 
     dataset = fields.ObjectField(
         properties={

--- a/tests/data/test_documents.py
+++ b/tests/data/test_documents.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring,too-few-public-methods,invalid-name
 
-""" Test cases for documents in ddionrails.data app """
+"""Test cases for documents in ddionrails.data app"""
 
 from os import getenv
 
@@ -60,6 +60,7 @@ class TestVariableDocuments(LiveServerTestCase):
             ),
         )
         expected["categories"] = {"labels": ["Yes"], "labels_de": ["Ja"]}
+        expected["name_keyword"] = expected["name"]
         # add facets to expected dictionary
         expected["analysis_unit"] = {
             "label": "Not Categorized",


### PR DESCRIPTION
## Proposed changes

Adds a search interface that only searches through variable names and
allows for limited regular expression usage.

Closes #1519
Closes #1305 
Closes #1064 

## Types of changes

Adds React code that does emulate the elasticsearch-ui look but performs functionallity separately from it 
to have full control over the Elasticsearch request.
